### PR TITLE
Fix where we load 64 bit dll's on windows.

### DIFF
--- a/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
+++ b/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.0" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.1" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
   </ItemGroup>
   

--- a/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
+++ b/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="$(MSBuildThisFileDirectory)..\LibZipSharp.props" />
   <PropertyGroup>
     <TargetFrameworks>net45</TargetFrameworks>
 
@@ -11,7 +11,7 @@
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Xamarin.LibZipSharp" Version="1.0.1" />
+    <PackageReference Include="Xamarin.LibZipSharp" Version="$(_LibZipSharpNugetVersion)" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
   </ItemGroup>
   

--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <_LibZipSharpNugetVersion>1.0.1</_LibZipSharpNugetVersion>
+    </PropertyGroup>
+</Project>

--- a/Native.cs
+++ b/Native.cs
@@ -411,7 +411,7 @@ namespace Xamarin.Tools.Zip
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
 				string executingDirectory = System.IO.Path.GetDirectoryName (typeof(Native).Assembly.Location);
 				if (Environment.Is64BitProcess) {
-					SetDllDirectory (System.IO.Path.Combine (executingDirectory, "x64"));
+					SetDllDirectory (System.IO.Path.Combine (executingDirectory, "lib64"));
 				}
 			}
 		}

--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -17,7 +17,7 @@
         -->
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <PackageId>Xamarin.LibZipSharp</PackageId>
-        <PackageVersion>1.0.0</PackageVersion>
+        <PackageVersion>1.0.1</PackageVersion>
         <Title>libZipSharp</Title>
         <Summary>A managed wrapper (and then some) around libzip (https://libzip.org/)</Summary>
         <Description>A managed wrapper (and then some) around libzip (https://libzip.org/)</Description>

--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="$(MSBuildThisFileDirectory)LibZipSharp.props" />
     <PropertyGroup>
         <AssemblyName>libZipSharp</AssemblyName>
         <AssemblyTitle>libZipSharp</AssemblyTitle>
@@ -17,7 +18,7 @@
         -->
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <PackageId>Xamarin.LibZipSharp</PackageId>
-        <PackageVersion>1.0.1</PackageVersion>
+        <PackageVersion>$(_LibZipSharpNugetVersion)</PackageVersion>
         <Title>libZipSharp</Title>
         <Summary>A managed wrapper (and then some) around libzip (https://libzip.org/)</Summary>
         <Description>A managed wrapper (and then some) around libzip (https://libzip.org/)</Description>


### PR DESCRIPTION
We were looking in the `x64` directory for
64 bit dll's on windows. However our Nuget
is installing them into `lib64`. This was
done to be compatible with Unix based
operating systems.

This PR updates the windows side to use the
same `lib64` directory.