### PR TITLE
Add TimeStamp Extra Fields

### DIFF
--- a/ExtraField.cs
+++ b/ExtraField.cs
@@ -30,7 +30,6 @@ namespace Xamarin.Tools.Zip
 	public class ExtraField
 	{
 		byte [] rawData;
-
 		public ushort ID { get; set; }
 		public ushort Length { get; set; }
 		public bool Local { get; set; }
@@ -39,7 +38,9 @@ namespace Xamarin.Tools.Zip
 		public bool DataValid { get; protected set; } = true;
 
 		public byte [] RawData { 
-			get { return rawData; }
+			get {
+				return rawData;
+			}
 			set {
 				rawData = value;
 				Parse ();
@@ -68,6 +69,11 @@ namespace Xamarin.Tools.Zip
 			DataValid = true;
 		}
 
+		internal virtual void Encode ()
+		{
+			DataValid = true;
+		}
+
 		protected ulong BytesToUnsignedLong (byte [] data, int startIndex)
 		{
 			if (data == null)
@@ -84,6 +90,16 @@ namespace Xamarin.Tools.Zip
 			               (data [startIndex + 2] << 16) |
 			               (data [startIndex + 1] << 8) |
 			               data [startIndex]);
+		}
+
+		protected byte[] UnsignedIntToBytes (uint data)
+		{
+			byte[] result = new byte[4];
+			result [0] = (byte)(data);
+			result [1] = (byte)(data >> 8);
+			result [2] = (byte)(data >> 16);
+			result [3] = (byte)(data >> 24);
+			return result;
 		}
 
 		protected uint BytesToUnsignedInt (byte [] data, int startIndex)

--- a/ExtraField_ExtendedTimestamp.cs
+++ b/ExtraField_ExtendedTimestamp.cs
@@ -24,6 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.IO;
 
 namespace Xamarin.Tools.Zip
 {
@@ -38,6 +39,18 @@ namespace Xamarin.Tools.Zip
 
 		public ExtraField_ExtendedTimestamp (ExtraField ef) : base (ef)
 		{}
+
+		public ExtraField_ExtendedTimestamp (ZipEntry entry, short fieldIndex, DateTime? createTime = null, DateTime? accessTime = null, DateTime? modificationTime = null, bool local = true)
+		{
+			ModificationTime = modificationTime ?? DateTime.MinValue;
+			CreationTime = createTime ?? DateTime.MinValue;
+			AccessTime = accessTime ?? DateTime.MinValue;
+			Local = local;
+			ID = KnownExtraFields.ExtendedTimestamp;
+			EntryIndex = entry.Index;
+			if (modificationTime.HasValue)
+				entry.ModificationTime = modificationTime.Value;
+		}
 
 		// Local-header version:
 		//
@@ -120,6 +133,77 @@ namespace Xamarin.Tools.Zip
 				CreationTime = Utilities.DateTimeFromUnixTime (BytesToUnsignedInt (data, index));
 
 			DataValid = true;
+		}
+
+		// Local-header version:
+		//
+		//          Value         Size        Description
+		//          -----         ----        -----------
+		//  (time)  0x5455        Short       tag for this extra block type ("UT")
+		//		    TSize         Short       total data size for this block
+		//          Flags         Byte        info bits
+		//          (ModTime)     Long        time of last modification (UTC/GMT)
+		//          (AcTime)      Long        time of last access (UTC/GMT)
+		//          (CrTime)      Long        time of original creation (UTC/GMT)
+		//
+		// Central-header version:
+		//
+		//          Value         Size        Description
+		//          -----         ----        -----------
+		//  (time)  0x5455        Short       tag for this extra block type ("UT")
+		//          TSize         Short       total data size for this block
+		//          Flags         Byte        info bits (refers to local header!)
+		//          (ModTime)     Long        time of last modification (UTC/GMT)
+		//
+		// The lower three bits of Flags in both headers indicate which timetamps are 
+		// present in the LOCAL extra field:
+		//		bit 0           if set, modification time is present
+		//		bit 1           if set, access time is present
+		//		bit 2           if set, creation time is present
+		//		bits 3-7        reserved for additional timestamps; not set
+		//
+		// Note that what we get here is JUST THE DATA - without the ID and TSize fields!
+		internal override void Encode()
+		{
+			base.Encode ();
+
+			DataValid = false;
+
+			MemoryStream data = new MemoryStream ();
+			byte flags = 0;
+			int expectedLength = 1; // Just the flags field - one byte
+			if (ModificationTime != DateTime.MinValue) {
+				flags |= 0x01;
+				expectedLength += 4;
+			}
+			if (AccessTime != DateTime.MinValue && Local) {
+				flags |= 0x02;
+				expectedLength += 4;
+			}
+			if (CreationTime != DateTime.MinValue && Local) {
+				flags |= 0x04;
+				expectedLength += 4;
+			}
+			data.WriteByte (flags);
+			if (ModificationTime != DateTime.MinValue) {
+				byte[] modDate = UnsignedIntToBytes ((uint)Utilities.UnixTimeFromDateTime (ModificationTime));
+				data.Write (modDate, 0, modDate.Length);
+			}
+			if (AccessTime != DateTime.MinValue && Local) {
+				byte[] accDate = UnsignedIntToBytes ((uint)Utilities.UnixTimeFromDateTime (AccessTime));
+				data.Write (accDate, 0, accDate.Length);
+			}
+			if (CreationTime != DateTime.MinValue && Local) {
+				byte[] createDate = UnsignedIntToBytes ((uint)Utilities.UnixTimeFromDateTime (CreationTime));
+				data.Write (createDate, 0, createDate.Length);
+			}
+
+			if (data.Length != expectedLength) {
+				DataValid = false;
+				return;
+			}
+			Length = (ushort)data.Length;
+			RawData = data.ToArray ();
 		}
 	}
 }

--- a/IPlatformServices.cs
+++ b/IPlatformServices.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Tools.Zip
 		bool SetEntryPermissions (ZipArchive archive, string sourcePath, ulong index, EntryPermissions permissions);
 		bool SetEntryPermissions (ZipArchive archive, ulong index, EntryPermissions permissions, bool isDirectory);
 		bool ReadAndProcessExtraFields (ZipEntry entry);
-		bool WriteExtraFields (ZipEntry entry, IList<ExtraField> extraFields);
+		bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields);
 		bool SetFileProperties (ZipEntry entry, string extractedFilePath, bool throwOnNativeErrors);
 		bool ExtractSpecialFile (ZipEntry entry, string destinationDir);
 	}

--- a/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
+++ b/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
@@ -18,11 +18,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\libZipSharp.csproj" Condition="'$(ReferenceNuget)' != 'True'" />
-    <None Include="..\build\Darwin\64\lib\libzip.5.0.dylib" Condition="'$(ReferenceNuget)' != 'True'">
+    <None Include="..\build\Darwin\64\lib\libzip.5.0.dylib" Condition="'$(ReferenceNuget)' != 'True' And Exists ('..\build\Darwin\64\lib\libzip.5.0.dylib')">
       <Link>libzip.dylib</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="..\build\Windows\64\lib\libzip.dll" Condition="'$(ReferenceNuget)' != 'True'">
+    <None Include="..\build\Windows\64\lib\libzip.dll" Condition="'$(ReferenceNuget)' != 'True' And Exists ('..\build\Windows\64\lib\libzip.dll')">
       <Link>libzip.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Native.cs
+++ b/Native.cs
@@ -237,11 +237,11 @@ namespace Xamarin.Tools.Zip
 		public static extern IntPtr zip_file_extra_field_get_by_id (IntPtr archive, UInt64 index, UInt16 extra_field_id, UInt16 extra_field_index, out UInt16 lenp, OperationFlags flags);
 
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int zip_file_extra_field_set (IntPtr archive, UInt64 index, UInt16 extra_field_id, UInt16 extra_field_index, byte[] extra_field_data, UInt16 len, OperationFlags flags);
+		static extern int zip_file_extra_field_set (IntPtr archive, UInt64 index, UInt16 extra_field_id, UInt16 extra_field_index, byte[] extra_field_data, UInt16 len, OperationFlags flags);
 
 		public static int zip_file_extra_field_set (IntPtr archive, UInt64 index, UInt16 extra_field_id, UInt16 extra_field_index, byte[] extra_field_data, OperationFlags flags)
 		{
-			return zip_file_extra_field_set (archive, index, extra_field_id, extra_field_index, extra_field_data, (UInt16)(extra_field_data == null ? 0 : extra_field_data.Length), flags);
+			return zip_file_extra_field_set (archive, index, extra_field_id, extra_field_index, extra_field_data, (UInt16)(extra_field_data.Length), flags);
 		}
 
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]

--- a/PlatformServices.cs
+++ b/PlatformServices.cs
@@ -136,12 +136,12 @@ namespace Xamarin.Tools.Zip
 			CallServices ((IPlatformServices services) => services.ReadAndProcessExtraFields (entry));
 		}
 
-		public void WriteExtraFields (ZipEntry entry, IList<ExtraField> extraFields = null)
+		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields = null)
 		{
 			if (entry == null)
 				throw new ArgumentNullException (nameof (entry));
 			
-			CallServices ((IPlatformServices services) => services.WriteExtraFields (entry, extraFields));
+			return CallServices ((IPlatformServices services) => services.WriteExtraFields (archive, entry, extraFields));
 		}
 
 		public void SetFileProperties (ZipEntry entry, string extractedFilePath, bool throwOnNativeExceptions = true)

--- a/UnixPlatformServices.cs
+++ b/UnixPlatformServices.cs
@@ -298,13 +298,19 @@ namespace Xamarin.Tools.Zip
 			}
 		}
 
-		public bool WriteExtraFields (ZipEntry entry, IList<ExtraField> extraFields)
+		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields)
 		{
 			if (entry == null)
 				return false;
 
-
-			throw new NotImplementedException ();
+			foreach (var field in extraFields) {
+				field.Encode ();
+				int result = Native.zip_file_extra_field_set (archive.ArchivePointer, entry.Index, field.ID, field.FieldIndex, field.RawData, field.Local ? OperationFlags.Local : OperationFlags.Central);
+				if (result < 0) {
+					return false;
+				}
+			}
+			return true;
 		}
 
 		public bool SetEntryPermissions (ZipArchive archive, ulong index, EntryPermissions requestedPermissions, bool isDirectory)

--- a/WindowsPlatformServices.cs
+++ b/WindowsPlatformServices.cs
@@ -227,8 +227,18 @@ namespace Xamarin.Tools.Zip
 			return true;
 		}
 
-		public bool WriteExtraFields (ZipEntry entry, IList<ExtraField> extraFields)
+		public bool WriteExtraFields (ZipArchive archive, ZipEntry entry, IList<ExtraField> extraFields)
 		{
+			if (entry == null)
+				return false;
+
+			foreach (var field in extraFields) {
+				field.Encode ();
+				int result = Native.zip_file_extra_field_set (archive.ArchivePointer, entry.Index, field.ID, field.FieldIndex, field.RawData, field.Local ? OperationFlags.Local : OperationFlags.Central);
+				if (result < 0) {
+					return false;
+				}
+			}
 			return true;
 		}
 


### PR DESCRIPTION
We have a weird problem where the Modified Date of the entry in a zip is somehow OLDER than the source file it is created from. Its consistently 1 second older, but its not 100% of the time. It seems like some sort of rounding error 🤷‍♂

It turns out this is a limitation of the Zip file format. If we read the Structure document [1] we come across this sentence.

The FAT filesystem of DOS has a timestamp resolution of only two seconds; ZIP file records mimic this. As a result, the built-in timestamp resolution of files in a ZIP archive is only two seconds, though extra fields can be used to store more precise timestamps.
So a modified date in a zip file can be one of TWO seconds. We can confirm this issue by looking at the time encoding functions used within lib zip itself. The Encoding code makes used of bit shifting to encode the unix timestamp into the required Zip format. The Decoding code reverses this operation. So lets run through a few examples.

So given a time of 12:46 and 29 seconds if we run through the code we get a value of 26062 to store in the zip file local header. If we use 12:46 and 30 seconds we get 26063. So far so go. Now let's plug these encoded values into our decoding code (x << 1) & 62.

(26062 << 1) & 62 = 28
(26063 << 1) & 62 = 30

As you can see while the 30 second timestamp decoded correctly, the 29 second one did not. So when we convert these values back to DateTime values we can end up with a timestamp that is 1 second in the past as it always rounds down. This is not great when we want to try to compare timestamps with files created on disk. Say a file was created at 29 seconds and we create the zip at the same time (within a second), according to the zip it would have been created at 28 seconds. So if we use the timestamps to compare it will thing the file is NEWER. Because this only happens if the zip and the file are created within the same 1 second timespan, this is not always a problem.

To fix this issue the zip file format has the ability to add "Extra" fields to the zip for various purposes. One of which is the Timestamp Extended field. This allows use to store the actual unix time to the second within the zip file as an additional entry. We can then read this field and update the Modified date accordingly. This works around the issue with the DOS timestamp resolution. 

This commit adds support for creating this new timestamp extra field. We already had support for reading them. So any zip created by LibZipSharp will automatically get this field on every platform. 

[1] https://en.wikipedia.org/wiki/Zip_(file_format)#Structure