### PR TITLE
[build] add the Xamarin-Secrets variable group

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,8 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
+variables:
+  - group: Xamarin-Secrets
 stages:
   - stage: Build
     jobs:


### PR DESCRIPTION
The signing step is failing with:

```
github--pat--xamarinreleasemanager : The term 'github--pat--xamarinreleasemanager' is not recognized as the name of a 
cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify 
that the path is correct and try again.
At C:\agent\_work\_temp\998d7548-da5e-464f-ba85-25605673e414.ps1:24 char:13
+ $token = "$(github--pat--xamarinreleasemanager)"
```