### PR TITLE
Fix for System.Buffers.ArrayPool

### DIFF
--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -138,5 +138,24 @@ namespace Tests {
 				Assert.AreEqual (date, WithoutMilliseconds (entry.ModificationTime), $"Check 1 {WithoutMilliseconds (entry.ModificationTime)} != {date}");
 			}
 		}
+
+		[Test]
+		public void SmallTextFile ()
+		{
+			var zipStream = new MemoryStream ();
+			var encoding = Encoding.UTF8;
+			using (var zip = ZipArchive.Create (zipStream)) {
+				zip.AddEntry ("foo", "bar", encoding);
+			}
+			using (var zip = ZipArchive.Open (zipStream)) {
+				var entry = zip.ReadEntry ("foo");
+				Assert.IsNotNull (entry, "Entry 'foo' should exist!");
+				using (var stream = new MemoryStream ()) {
+					entry.Extract (stream);
+					stream.Position = 0;
+					Assert.AreEqual ("bar", encoding.GetString (stream.ToArray ()));
+				}
+			}
+		}
 	}
 }

--- a/ZipArchive.cs
+++ b/ZipArchive.cs
@@ -751,7 +751,7 @@ namespace Xamarin.Tools.Zip
 					try {
 						Marshal.Copy (data, buffer, 0, length);
 						stream.Write (buffer, 0, length);
-						return buffer.Length;
+						return length;
 					} finally {
 						ArrayPool<byte>.Shared.Return (buffer);
 					}


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/4320

After using libZipSharp 1.0.9 in xamarin-android, one of our tests
surfaced a bug:

    Xamarin.Tools.Zip.ZipIOException : Stream is not a ZIP archive

The test created a small text file inside a zip using a `MemoryStream`.

Something like:

    using (var zip = ZipArchive.Create (zipStream)) {
        zip.AddEntry ("foo", "bar", encoding);
    }

In 750c780e, there was one mistake:

    case SourceCommand.Write:
        buffer = ArrayPool<byte>.Shared.Rent (length);
        try {
            Marshal.Copy (data, buffer, 0, length);
            stream.Write (buffer, 0, length);
            return buffer.Length; // Whoops!
        } finally {
            ArrayPool<byte>.Shared.Return (buffer);
        }

In the test case above, the size of the buffer will be very small: the
equivalent of `Encoding.UTF8.GetBytes("bar")`. If `ArrayPool` returns
a *larger* buffer than we asked for, the code is actually wrong.

We need to return `length` instead of `buffer.Length`. I would suspect
that almost everything worked with this bug in place, except for this
case. `xaprepare` was able to do its work: downloading and unzipping
the Android SDK/NDK.

I was able to add a unit test showing this problem.