### PR TITLE
Throw exception instead of silently failing if zip save/close fails

### DIFF
--- a/ZipArchive.cs
+++ b/ZipArchive.cs
@@ -843,8 +843,7 @@ namespace Xamarin.Tools.Zip
 			try {
 				if (Native.zip_close (archive) < 0)
 					throw GetErrorException ();
-			}
-			finally {
+			} finally {
 				foreach (var s in sources) {
 					s.Dispose ();
 				}

--- a/ZipArchive.cs
+++ b/ZipArchive.cs
@@ -840,12 +840,17 @@ namespace Xamarin.Tools.Zip
 			if (archive == IntPtr.Zero)
 				return;
 
-			Native.zip_close (archive);
-			foreach (var s in sources) {
-				s.Dispose ();
+			try {
+				if (Native.zip_close (archive) < 0)
+					throw GetErrorException ();
 			}
-			sources.Clear ();
-			archive = IntPtr.Zero;
+			finally {
+				foreach (var s in sources) {
+					s.Dispose ();
+				}
+				sources.Clear ();
+				archive = IntPtr.Zero;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
I saw a case before on my machine where closing the zip would fail to write out changes, but it would fail silently, so it wasn't obvious there was a problem there.

See more details here: https://xamarinhq.slack.com/archives/C03CEGRUW/p1588784048377800

This PR makes those errors explicit, throwing an exception on Close failures, so that the user will see there's a problem, that the ZIP/APK didn't actually get updated.

I'm honestly a little nervous about this change - it seems good conceptually but might there be cases in practice where it's better to fail silently?
I'm not sure, but I wanted to create a PR to get feedback from you all on that.

As for my machine, it was a failure to create temp file error (see Slack). The problem went away after I rebooted and I wasn't able to reproduce it again. Probably it was some file in use issue of some kind. This may or may not be a problem customers see in practice (of course, since it fails silently, we have less visibility into whether it is a problem in practice - making the error explicit would help with that at least).