### PR TITLE
Make 64 bit Linux native lib the default.

### DIFF
--- a/Xamarin.LibZipSharp.targets
+++ b/Xamarin.LibZipSharp.targets
@@ -19,10 +19,10 @@
       <Link>%(FileName)%(Extension)</Link>
     </_LibZipNativeLibs>
     <_LibZipNativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\libzip.so">
-      <Link>lib64\%(FileName)%(Extension)</Link>
+      <Link>%(FileName)%(Extension)</Link>
     </_LibZipNativeLibs>
     <_LibZipNativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x86\native\libzip.so">
-      <Link>%(FileName)%(Extension)</Link>
+      <Link>lib32\%(FileName)%(Extension)</Link>
     </_LibZipNativeLibs>
     <None Include="@(_LibZipNativeLibs)" Condition="'$(LibZipSharpBundleAllNativeLibraries)' == 'True'">
       <Link>%(Link)</Link>

--- a/libZipSharp.dll.config
+++ b/libZipSharp.dll.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<dllmap dll="libzip" os="osx" target="libzip.dylib"/>
-	<dllmap dll="libzip" os="linux" cpu="x86" target="libzip.so"/>
-	<dllmap dll="libzip" os="linux" cpu="x86-64" target="lib64/libzip.so"/>
+	<dllmap dll="libzip" os="linux" cpu="x86" target="lib32/libzip.so"/>
+	<dllmap dll="libzip" os="linux" cpu="x86-64" target="libzip.so"/>
 </configuration>


### PR DESCRIPTION
Since 64bit OS's are more common we should
make the 64 bit version of the native ibrary
the default.

This helps when running under .net Core. But
it will also allow us to easliy remove the
32 bit version in the future.