### PR TITLE
Fix Native Crash on Windows.

### DIFF
--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <_LibZipSharpNugetVersion>1.0.16</_LibZipSharpNugetVersion>
+        <_LibZipSharpNugetVersion>1.0.17</_LibZipSharpNugetVersion>
     </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,9 +24,9 @@ stages:
             sudo apt -f -u install ninja-build gcc-multilib lib32z1-dev zlib1g-dev libssl-dev libssl1.1:i386 libssl-dev:i386 libc-dev:i386 libc6-dev-i386 -y
             git submodule update --init --recursive
           displayName: 'Install Tools'
-#        - bash: |
-#            patch --verbose -d external/libzip -p1 -l < libzip-static.patch
-#          displayName: 'Apply Patch'
+        - bash: |
+            patch --verbose -d external/libzip -p1 -l < libzip-changes.patch
+          displayName: 'Apply Patch'
         - bash: |
             ./build_native
           displayName: 'Build Linux x64'
@@ -37,16 +37,16 @@ stages:
         - task: ArchiveFiles@2
           inputs:
             rootFolderOrFile: build/Linux/32/lib/libzip.so.5.3
-            includeRootFolder: false 
+            includeRootFolder: false
             archiveType: 7z
-            replaceExistingArchive: true 
+            replaceExistingArchive: true
             archiveFile: $(Build.ArtifactStagingDirectory)/libzip-linux-x86.7z
         - task: ArchiveFiles@2
           inputs:
             rootFolderOrFile: build/Linux/64/lib/libzip.so.5.3
-            includeRootFolder: false 
+            includeRootFolder: false
             archiveType: 7z
-            replaceExistingArchive: true 
+            replaceExistingArchive: true
             archiveFile: $(Build.ArtifactStagingDirectory)/libzip-linux-x64.7z
         - task: PublishBuildArtifacts@1
           displayName: upload artifacts
@@ -65,6 +65,9 @@ stages:
             brew install ninja xamarin/xamarin-android-windeps/mingw-zlib
             git submodule update --init --recursive
           displayName: 'Install toolchain'
+        - bash: |
+            patch --verbose -d external/libzip -p1 -l < libzip-changes.patch
+          displayName: 'Apply Patch'
         - bash: |
             HOSTOS=Darwin ./build_native
             ./build_windows
@@ -97,7 +100,7 @@ stages:
           inputs:
             solution: libZipSharp.csproj
             configuration: Release
-            msbuildArguments: /restore /v:diag 
+            msbuildArguments: /restore /v:diag
         - task: MSBuild@1
           displayName: NuGet pack libZipSharp
           inputs:

--- a/libzip-changes.patch
+++ b/libzip-changes.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/zip_stat_index.c b/lib/zip_stat_index.c
+index 0f8bead8..62dc0455 100644
+--- a/lib/zip_stat_index.c
++++ b/lib/zip_stat_index.c
+@@ -55,7 +55,7 @@ zip_stat_index(zip_t *za, zip_uint64_t index, zip_flags_t flags, zip_stat_t *st)
+             return -1;
+         }
+
+-        if (entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
++        if (entry->changes != NULL && entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
+             st->mtime = de->last_mod;
+             st->valid |= ZIP_STAT_MTIME;
+         }


### PR DESCRIPTION
We had a problem in Xamarin.Android where libzip
would crash on our test machine. This turned out
to be a bung in libzip itself. [https://github.com/nih-at/libzip/pull/202](https://github.com/nih-at/libzip/pull/202)

There was a missing `NULL` check in `zip_stat_index`.
This PR adds a patch to allow us to patch this problem
in the latest release of `libzip` so that we can
bump to the latest version in Xamrain.Android.