### PR TITLE
Fix Windows to look in Assembly Directory for 32bit dll.

### DIFF
--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <_LibZipSharpNugetVersion>1.0.17</_LibZipSharpNugetVersion>
+        <_LibZipSharpNugetVersion>1.0.18</_LibZipSharpNugetVersion>
     </PropertyGroup>
 </Project>

--- a/Native.cs
+++ b/Native.cs
@@ -415,9 +415,7 @@ namespace Xamarin.Tools.Zip
 		{
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
 				string executingDirectory = System.IO.Path.GetDirectoryName (typeof(Native).Assembly.Location);
-				if (Environment.Is64BitProcess) {
-					SetDllDirectory (System.IO.Path.Combine (executingDirectory, "lib64"));
-				}
+				SetDllDirectory (Environment.Is64BitProcess ? System.IO.Path.Combine (executingDirectory, "lib64") : executingDirectory);
 			}
 		}
 	}


### PR DESCRIPTION
Commit 96eb5e34 introduced the use of `DefaultDllImportSearchPathsAttribute`
to add extra security when loading native libraries. This
works fine when the executable that is running is in the
same directory as the `LibZipSharp.dll` and the `libzip.dll`.

However when the executable has a different `WorkingDirectory`
as the `LibZipSharp.dll` this then causes the following
error.

	System.DllNotFoundException: Unable to load DLL 'libzip'

This is because with the new attribute only Safe paths are searched.
So when we run this under MSBuild.exe for example, the `Working`
directory will definately NOT contain the 32bit `libzip.dll`.

The fix to to always set the location of the `libzip.dll` via
`SetDllDirectory` for both 32bit and 64bit processes.

Also bump to 1.0.18