### PR TITLE
Fix Dll SearchPath to include Assembly Directory.

### DIFF
--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <_LibZipSharpNugetVersion>1.0.18</_LibZipSharpNugetVersion>
+        <_LibZipSharpNugetVersion>1.0.19</_LibZipSharpNugetVersion>
     </PropertyGroup>
 </Project>

--- a/Native.cs
+++ b/Native.cs
@@ -27,7 +27,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-[assembly: DefaultDllImportSearchPathsAttribute(DllImportSearchPath.SafeDirectories)]
+[assembly: DefaultDllImportSearchPathsAttribute(DllImportSearchPath.SafeDirectories | DllImportSearchPath.AssemblyDirectory)]
 
 namespace Xamarin.Tools.Zip
 {


### PR DESCRIPTION
Commit 28b46390 added the ability to load the 32bit
dll from the current directory. However on MacOS/dotnet
this does not work. The current `DllImportSearchPath`
setting only allows for loading from known `Safe` paths.

On MacOS/dotnet it seems this does not include the
assembly directoy. Our current setup in Xamarin.Android
places the native libaries in the same directory as
the assembly, so we need that to work.

The fix is to include the value `AssemblyDirectory` in the
`DllImportSearchPath` setting as well as the `SafeDirectories`
value. This should allow `dotnet` to find native libraries which
are in the same directory.