### PR TITLE
Build on Windows again

### DIFF
--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <_LibZipSharpNugetVersion>1.0.20</_LibZipSharpNugetVersion>
+        <_LibZipSharpNugetVersion>1.0.21-rc</_LibZipSharpNugetVersion>
     </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,60 @@ variables:
 stages:
   - stage: Build
     jobs:
+    - job: buildWindows
+      pool:
+        vmImage: windows-latest
+      variables:
+        LIBZIP_FEATURES: -DENABLE_COMMONCRYPTO=OFF -DENABLE_GNUTLS=OFF -DENABLE_MBEDTLS=OFF -DENABLE_OPENSSL=OFF -DENABLE_WINDOWS_CRYPTO=OFF -DBUILD_TOOLS=OFF -DBUILD_REGRESS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_DOC=OFF -DENABLE_BZIP2=OFF -DENABLE_LZMA=OFF
+        COMMON_CMAKE_PARAMS: -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=ON -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
+      steps:
+        - script: |
+            echo "Hello"
+            git submodule update --init --recursive
+          displayName: "Update Submodules"
+        - script: |
+            cd external/libzip
+            git apply -v ../../libzip-changes.patch
+          displayName: "Apply Patches"
+        - script: |
+            cd external/vcpkg
+            bootstrap-vcpkg.bat
+          displayName: "Build vcpkg"
+        - script: |
+            external\vcpkg\vcpkg.exe integrate install
+            external\vcpkg\vcpkg.exe install zlib:x64-windows-static
+            mkdir .\build\Windows\64
+            cd .\build\Windows\64
+            cmake $(LIBZIP_FEATURES) $(COMMON_CMAKE_PARAMS) -DZLIB_ROOT=..\..\..\external\vcpkg\installed\x64-windows-static -A x64 ..\..\..\external\libzip
+            cmake --build . --config Release -v
+          displayName: "x64 Build"
+        - script: |
+            external\vcpkg\vcpkg.exe integrate install
+            external\vcpkg\vcpkg.exe install zlib:x86-windows-static
+            mkdir .\build\Windows\32
+            cd .\build\Windows\32
+            cmake $(LIBZIP_FEATURES) $(COMMON_CMAKE_PARAMS) -DZLIB_ROOT=..\..\..\external\vcpkg\installed\x86-windows-static -A Win32 ..\..\..\external\libzip
+            cmake --build . --config Release -v
+          displayName: "x86 Build"
+        - task: ArchiveFiles@2
+          inputs:
+            rootFolderOrFile: build\Windows\32\lib\Release\zip.dll
+            includeRootFolder: false
+            archiveType: 7z
+            replaceExistingArchive: true
+            archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-x86.7z
+        - task: ArchiveFiles@2
+          inputs:
+            rootFolderOrFile: build\Windows\64\lib\Release\zip.dll
+            includeRootFolder: false
+            archiveType: 7z
+            replaceExistingArchive: true
+            archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-x64.7z
+        - task: PublishBuildArtifacts@1
+          displayName: upload artifacts
+          inputs:
+            artifactName: 'native'
+            pathtoPublish: $(Build.ArtifactStagingDirectory)
     - job: buildLinux
       pool:
         vmImage: ubuntu-16.04
@@ -55,7 +109,9 @@ stages:
             artifactName: 'native'
             pathtoPublish: $(Build.ArtifactStagingDirectory)
     - job: buildMacOS
-      dependsOn: buildLinux
+      dependsOn:
+        - buildlinux
+        - buildWindows
       pool:
         vmImage: macOS-10.14
       steps:
@@ -71,9 +127,10 @@ stages:
           displayName: 'Apply Patch'
         - bash: |
             HOSTOS=Darwin ./build_native
-            ./build_windows
             mkdir -p build/Linux/64
             mkdir -p build/Linux/32
+            mkdir -p build/Windows/64
+            mkdir -p build/Windows/32
             find build/* | grep libzip
           displayName: 'Build native and Windows'
         - task: DownloadBuildArtifacts@0
@@ -91,10 +148,23 @@ stages:
           inputs:
             archiveFilePatterns: $(Build.ArtifactStagingDirectory)/native/libzip-linux-x86.7z
             destinationFolder: build/Linux/32
+        - task: ExtractFiles@1
+          displayName: Extract 64 bit Windows native
+          inputs:
+            archiveFilePatterns: $(Build.ArtifactStagingDirectory)/native/libzip-windows-x64.7z
+            destinationFolder: build/Windows/64
+        - task: ExtractFiles@1
+          displayName: Extract 32 bit Windows native
+          inputs:
+            archiveFilePatterns: $(Build.ArtifactStagingDirectory)/native/libzip-windows-x86.7z
+            destinationFolder: build/Windows/32
         - bash: |
             mv build/Linux/32/libzip.so.5.3 build/Linux/32/libzip.so
             mv build/Linux/64/libzip.so.5.3 build/Linux/64/libzip.so
+            mv build/Windows/32/zip.dll build/Windows/32/libzip.dll
+            mv build/Windows/64/zip.dll build/Windows/64/libzip.dll
             rm $(Build.ArtifactStagingDirectory)/native/libzip-linux-*.7z
+            rm $(Build.ArtifactStagingDirectory)/native/libzip-windows-*.7z
           displayName: 'Find libzip'
         - task: MSBuild@1
           displayName: 'Build solution libZipSharp.csproj'

--- a/libZipSharp.csproj
+++ b/libZipSharp.csproj
@@ -13,7 +13,7 @@
         <DocumentationFile>libZipSharp.xml</DocumentationFile>
     </PropertyGroup>
     <PropertyGroup>
-        <!-- 
+        <!--
         nuget packaging
         -->
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -44,8 +44,8 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
         <None Include="build\Darwin\64\lib\libzip.5.3.dylib" PackagePath="runtimes\osx\native\libzip.dylib" Pack="true" />
-        <None Include="build\Windows\64\lib\libzip.dll" PackagePath="runtimes\win-x64\native\libzip.dll" Pack="true" />
-        <None Include="build\Windows\32\lib\libzip.dll" PackagePath="runtimes\win-x86\native\libzip.dll" Pack="true" />
+        <None Include="build\Windows\64\libzip.dll" PackagePath="runtimes\win-x64\native\libzip.dll" Pack="true" />
+        <None Include="build\Windows\32\libzip.dll" PackagePath="runtimes\win-x86\native\libzip.dll" Pack="true" />
         <None Include="build\Linux\64\libzip.so" PackagePath="runtimes\linux-x64\native\libzip.so" Pack="true" />
         <None Include="build\Linux\32\libzip.so" PackagePath="runtimes\linux-x86\native\libzip.so" Pack="true" />
         <None Include="LICENSE" PackagePath="Licences" Pack="true" />

--- a/libzip-changes.patch
+++ b/libzip-changes.patch
@@ -1,13 +1,13 @@
 diff --git a/lib/zip_stat_index.c b/lib/zip_stat_index.c
-index 0f8bead8..62dc0455 100644
+index 77993257..a1cba96a 100644
 --- a/lib/zip_stat_index.c
 +++ b/lib/zip_stat_index.c
 @@ -55,7 +55,7 @@ zip_stat_index(zip_t *za, zip_uint64_t index, zip_flags_t flags, zip_stat_t *st)
-             return -1;
-         }
-
--        if (entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
-+        if (entry->changes != NULL && entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
-             st->mtime = de->last_mod;
-             st->valid |= ZIP_STAT_MTIME;
-         }
+ 	    return -1;
+ 	}
+ 
+-	if (entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
++	if (entry->changes != NULL && entry->changes->changed & ZIP_DIRENT_LAST_MOD) {
+ 	    st->mtime = de->last_mod;
+ 	    st->valid |= ZIP_STAT_MTIME;
+ 	}


### PR DESCRIPTION
Commit 755a42a8 reverted the system which built the native libzip.dll in Windows. This was because we suspected that the change from using mingw was causing a runtime crash. However this turned out not to be the case (see https://github.com/xamarin/LibZipSharp/pull/67).

So this PR adds back in the code which builds the windows dll on windows.   

It also updates the libzip-changes.patch so that it would apply on windows via `git apply`. This patch now works on all platforms. 

Also testing out a new release package system. Rather than just publishing to stable on nuget, we will first publish an `x.x.x-rc` release candidate. This will allow us to do a test PR on xamarin.android without breaking the current stable package. We had a situation over the last few months where the "stable" package actually had a crash on windows. This is not ideal for people consuming the nuget. 

So from now on we will publish an `-rc` do a bump in xamarin.android and if that passes, then we can publish a stable release. 