### PR TITLE
Do not use the XZ library (LZMA) by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ cmake_minimum_required(VERSION 3.18)
 
 option(BUILD_DEPENDENCIES "Build only libzip dependencies" OFF)
 option(BUILD_LIBZIP "Build libzip and libZipSharp" OFF)
+option(ENABLE_XZ "Enable XZ (LZMA compression) in the build" OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE True CACHE BOOL "Always build position independent code" FORCE)
 
@@ -44,6 +45,10 @@ set(ENABLE_GNUTLS OFF CACHE BOOL "Do not use gnutls for libzip" FORCE)
 set(ENABLE_OPENSSL OFF CACHE BOOL "Do not use OpenSSL for libzip" FORCE)
 set(ENABLE_MBEDTLS OFF CACHE BOOL "Do not use mbedtls for libzip" FORCE)
 set(ENABLE_WINDOWS_CRYPTO OFF CACHE BOOL "Do not use Windows Crypto" FORCE)
+
+if(NOT ENABLE_XZ)
+  set(ENABLE_LZMA OFF CACHE BOOL "Do not use XZ for libzip" FORCE)
+endif()
 
 #
 # zlib-ng
@@ -291,7 +296,7 @@ if(BUILD_DEPENDENCIES)
     -fvisibility=hidden
     )
 
-if(NOT WIN32)
+if(NOT WIN32 AND ENABLE_XZ)
   add_subdirectory(external/xz)
 
   target_compile_options(
@@ -347,10 +352,12 @@ else()
   set(ZLIB_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
   set(BZip2_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
 
-  if(WIN32)
-    find_package(LibLZMA CONFIG REQUIRED)
-  else()
-    set(LibLZMA_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
+  if(ENABLE_XZ)
+    if(WIN32)
+      find_package(LibLZMA CONFIG REQUIRED)
+    else()
+      set(LibLZMA_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
+    endif()
   endif()
 
   list(PREPEND CMAKE_PREFIX_PATH "${ARTIFACTS_ROOT_DIR}")
@@ -401,7 +408,11 @@ else()
     LIBZIPSHARP_VERSION="${LZS_VERSION}"
     )
 
-  message(STATUS "LZMA: ${LIBLZMA_INCLUDE_DIR}")
+  if(ENABLE_XZ)
+    message(STATUS "LZMA: ${LIBLZMA_INCLUDE_DIR}")
+  else()
+    message(STATUS "LZMA: DISABLED")
+  endif()
   message(STATUS "ZLIB: ${ZLIB_INCLUDE_DIR}")
   message(STATUS "BZ2: ${BZIP2_INCLUDE_DIR}")
 
@@ -409,10 +420,24 @@ else()
     ${PROJECT_NAME}
     PRIVATE
     ${ZLIB_INCLUDE_DIR}
-    ${LIBLZMA_INCLUDE_DIR}
     ${BZIP2_INCLUDE_DIR}
     ${CMAKE_BINARY_DIR}/external/libzip
     )
+
+  if(ENABLE_XZ)
+    target_include_directories(
+      ${PROJECT_NAME}
+      PRIVATE
+      ${LIBLZMA_INCLUDE_DIR}
+      )
+
+    target_compile_definitions(
+      ${PROJECT_NAME}
+      PRIVATE
+      HAVE_XZ=1
+      )
+  endif()
+
   target_compile_options(
     ${PROJECT_NAME}
     PRIVATE
@@ -472,30 +497,45 @@ else()
 
     set(ZLIB_PATH "${CMAKE_BINARY_DIR}/libz-fat.a")
     set(BZ2_PATH "${CMAKE_BINARY_DIR}/libbz2-fat.a")
-    set(LZMA_PATH "${CMAKE_BINARY_DIR}/liblzma-fat.a")
+
+    if(ENABLE_XZ)
+      set(LZMA_PATH "${CMAKE_BINARY_DIR}/liblzma-fat.a")
+    endif()
 
     make_fat_archive("${ARTIFACTS_ROOT_DIR}/lib/libz.a" "${ARTIFACTS_OTHER_ROOT_DIR}/lib/libz.a" "${ZLIB_PATH}")
     make_fat_archive("${ARTIFACTS_ROOT_DIR}/lib/libbz2.a" "${ARTIFACTS_OTHER_ROOT_DIR}/lib/libbz2.a" "${BZ2_PATH}")
-    make_fat_archive("${ARTIFACTS_ROOT_DIR}/lib/liblzma.a" "${ARTIFACTS_OTHER_ROOT_DIR}/lib/liblzma.a" "${LZMA_PATH}")
+
+    if(ENABLE_XZ)
+      make_fat_archive("${ARTIFACTS_ROOT_DIR}/lib/liblzma.a" "${ARTIFACTS_OTHER_ROOT_DIR}/lib/liblzma.a" "${LZMA_PATH}")
+    endif()
 
     set(LIBS
       ${ZLIB_PATH}
       ${BZ2_PATH}
-      ${LZMA_PATH}
       )
+
+    if(ENABLE_XZ)
+      list(APPEND LIBS ${LZMA_PATH})
+    endif()
   else()
     if(WIN32)
       set(LIBS
         ${ARTIFACTS_ROOT_DIR}/lib/zlib.lib
         ${ARTIFACTS_ROOT_DIR}/lib/bz2.lib
-        LibLZMA::LibLZMA
         )
+
+      if(ENABLE_XZ)
+        list(APPEND LIBS LibLZMA::LibLZMA)
+      endif()
     else()
       set(LIBS
         ${ARTIFACTS_ROOT_DIR}/lib/libz.a
         ${ARTIFACTS_ROOT_DIR}/lib/libbz2.a
-        ${ARTIFACTS_ROOT_DIR}/lib/liblzma.a
         )
+
+      if(ENABLE_XZ)
+        list(APPEND LIBS ${ARTIFACTS_ROOT_DIR}/lib/liblzma.a)
+      endif()
     endif()
   endif()
 

--- a/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
+++ b/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(MSBuildThisFileDirectory)..\LibZipSharp.props" />
+
   <PropertyGroup>
     <TargetFrameworks>net471;netcoreapp3.1</TargetFrameworks>
 
@@ -6,9 +9,8 @@
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
     <ReferenceNuget Condition="'$(ReferenceNuget)' == ''">False</ReferenceNuget>
     <DefineConstants Condition="'$(OS)' == 'Windows_NT'">$(DefineConstants);WINDOWS</DefineConstants>
+    <DefineConstants Condition=" '$(UseXZ)' == 'True' ">$(DefineConstants);HAVE_XZ</DefineConstants>
   </PropertyGroup>
-
-  <Import Project="$(MSBuildThisFileDirectory)..\LibZipSharp.props" />
 
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -32,7 +32,9 @@ namespace Tests {
 			Assert.IsNotEmpty (versions.LibZip, "libzip version must not be empty");
 			Assert.IsNotEmpty (versions.Zlib, "zlib version must not be empty");
 			Assert.IsNotEmpty (versions.ZlibNG, "zlib-ng version must not be empty");
+#if HAVE_XZ
 			Assert.IsNotEmpty (versions.LZMA, "LZMA version must not be empty");
+#endif
 			Assert.IsNotEmpty (versions.LibZipSharp, "LibZipSharp version must not be empty");
 
 			Console.WriteLine ($"LibZipSharp version: {versions.LibZipSharp}");
@@ -214,7 +216,9 @@ namespace Tests {
 
 		[TestCase (CompressionMethod.Deflate)]
 		[TestCase (CompressionMethod.Bzip2)]
+#if HAVE_XZ
 		[TestCase (CompressionMethod.XZ)]
+#endif
 		public void UpdateEntryCompressionMethod (CompressionMethod method)
 		{
 			var zipStream = new MemoryStream ();

--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -3,5 +3,6 @@
     <_LibZipSharpNugetVersion>2.0.0</_LibZipSharpNugetVersion>
     <_NativeBuildDir>$(MSBuildThisFileDirectory)lzsbuild</_NativeBuildDir>
     <_ExternalDir>$(MSBuildThisFileDirectory)external</_ExternalDir>
+    <UseXZ Condition=" '$(UseXZ)' == '' ">false</UseXZ>
   </PropertyGroup>
 </Project>

--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,7 @@ JOBS=""
 CONFIGURATION="RelWithDebInfo"
 REBUILD="no"
 VERBOSE="no"
+USE_XZ="no"
 
 # The color block is pilfered from the dotnet installer script
 #
@@ -75,6 +76,7 @@ where OPTIONS are one or more of:
   -n|--ninja PATH            use ninja at PATH instead of the default of '${NINJA}'
   -m|--cmake PATH            use cmake at PATH instead of the default of '${CMAKE}'
 
+  -x|--xz                    use the XZ library for LZMA support (default: ${USE_XZ})
   -c|--configuration NAME    build using configuration NAME instead of the default of '${CONFIGURATION}'
   -j|--jobs NUM              run at most this many build jobs in parallel
   -v|--verbose               make cmake and ninja verbose
@@ -117,11 +119,16 @@ function cmake_configure()
     fi
     shift
 
+    local use_xz
+    if [ "${USE_XZ}" == "yes" ]; then
+        use_xz="-DENABLE_XZ=ON"
+    fi
+
     run_cmake_common \
         -B "${build_dir}" \
         -S "${MY_DIR}" \
         -G Ninja \
-        -DCMAKE_BUILD_TYPE="${CONFIGURATION}" \
+        -DCMAKE_BUILD_TYPE="${CONFIGURATION}" ${use_xz} \
         "$@"
 }
 
@@ -223,9 +230,11 @@ while (( "$#" )); do
             fi
             ;;
 
+        -x|--xz) USE_XZ="yes"; shift ;;
+
         -v|--verbose) VERBOSE="yes"; shift ;;
 
-        -r|--rebuild) REBUILD="yes"; shift;;
+        -r|--rebuild) REBUILD="yes"; shift ;;
 
         -h|--help) usage; shift ;;
 
@@ -317,3 +326,7 @@ cmake_configure "${LZS_BUILD_DIR}" -DBUILD_LIBZIP=ON "-DARTIFACTS_ROOT_DIR=${ART
 
 print_banner "Building libZipSharpNative"
 cmake_build "${LZS_BUILD_DIR}"
+
+if [ "${USE_XZ}" == "yes" ]; then
+    echo "${BRIGHT_BLUE}DON'T FORGET TO BUILD THE MANAGED CODE WITH THE /p:UseXZ=True OPTION!${NORMAL}"
+fi

--- a/native/version.cc
+++ b/native/version.cc
@@ -1,7 +1,9 @@
 #include <cstring>
 #include <bzlib.h>
 #include <zlib.h>
+#if defined (HAVE_XZ)
 #include <lzma.h>
+#endif // def HAVE_XZ
 #include <zipconf.h>
 
 #include "version.hh"
@@ -10,7 +12,11 @@ constexpr char libzipsharp_version[] = LIBZIPSHARP_VERSION;
 constexpr char libzip_version[] = LIBZIP_VERSION;
 constexpr char libzlib_version[] = ZLIB_VERSION;
 constexpr char libzlibng_version[] = ZLIBNG_VERSION;
+#if defined (HAVE_XZ)
 constexpr char lzma_version[] = LZMA_VERSION_STRING;
+#else
+constexpr char lzma_version[] = "not supported";
+#endif // def HAVE_XZ
 
 void lzs_get_versions (LZSVersions *versions)
 {


### PR DESCRIPTION
Disable adding support for XZ (LZMA) compression by default. This is due
to the fact that XZ is licensed under `LGPL` and it may adversely affect
the licensing of the shared library we place in the nuget.

XZ can be enabled by passing the `--xz` option to the `build.sh` script
and by passing the `/p:UseXZ=True` option to the managed library build.