### PR TITLE
[nuget] Include Mono.Unix build assets

### DIFF
--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_LibZipSharpNugetVersion>2.0.0-alpha</_LibZipSharpNugetVersion>
+    <_LibZipSharpNugetVersion>2.0.0-alpha2</_LibZipSharpNugetVersion>
     <_NativeBuildDir>$(MSBuildThisFileDirectory)lzsbuild</_NativeBuildDir>
     <_ExternalDir>$(MSBuildThisFileDirectory)external</_ExternalDir>
     <_MonoPosixNugetVersion>7.0.0-alpha.21276.2</_MonoPosixNugetVersion>

--- a/LibZipSharp/libZipSharp.csproj
+++ b/LibZipSharp/libZipSharp.csproj
@@ -57,7 +57,7 @@
         <None Include="$(_ExternalDir)\zlib-ng\LICENSE.md" PackagePath="Licences\zlib-ng" Pack="true" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Mono.Unix" Version="$(_MonoPosixNugetVersion)" />
+      <PackageReference Include="Mono.Unix" Version="$(_MonoPosixNugetVersion)" PrivateAssets="analyzers" />
       <PackageReference Include="System.Buffers" Version="4.5.0" />
       <PackageReference Include="XliffTasks" Version="1.0.0-beta.20206.1" PrivateAssets="all" />
     </ItemGroup>


### PR DESCRIPTION
This is to make projects which reference only LibZipSharp work with the
new Mono.Unix package.  By default, the nuget generated for LibZipSharp
will not include Mono.Unix's `build` components which will break said
projects.  Transitive build assets must be included so that the
Mono.Unix configuration and runtime files are copied to the project
directory.