### PR TITLE
Use maximum compression instead of the default one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 #
 set(ZLIB_COMPAT ON CACHE BOOL "Build zlib-ng for compatibility with zlib" FORCE)
 set(ZLIB_ENABLE_TESTS OFF CACHE BOOL "Do not build zlib-ng tests" FORCE)
+set(WITH_NEW_STRATEGIES OFF CACHE BOOL "Disable faster, but with worse compression, deflate strategies" FORCE)
 
 #
 # Read product version

--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_LibZipSharpNugetVersion>2.0.0-alpha4</_LibZipSharpNugetVersion>
+    <_LibZipSharpNugetVersion>2.0.0-alpha5</_LibZipSharpNugetVersion>
     <_NativeBuildDir>$(MSBuildThisFileDirectory)lzsbuild</_NativeBuildDir>
     <_ExternalDir>$(MSBuildThisFileDirectory)external</_ExternalDir>
     <_MonoPosixNugetVersion>7.0.0-alpha8.21302.6</_MonoPosixNugetVersion>

--- a/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
@@ -329,7 +329,7 @@ namespace Xamarin.Tools.Zip
 			long index = Native.zip_file_add (archive, destPath, source, overwriteExisting ? OperationFlags.Overwrite : OperationFlags.None);
 			if (index < 0)
 				throw GetErrorException ();
-			if (Native.zip_set_file_compression (archive, (ulong)index, compressionMethod, 0) < 0)
+			if (Native.zip_set_file_compression (archive, (ulong)index, compressionMethod, 9) < 0)
 				throw GetErrorException ();
 			if (permissions == EntryPermissions.Default)
 				permissions = DefaultFilePermissions;
@@ -410,7 +410,7 @@ namespace Xamarin.Tools.Zip
 			long index = PlatformServices.Instance.StoreSpecialFile (this, sourcePath, archivePath, out compressionMethod);
 			if (index < 0)
 				throw GetErrorException ();
-			if (Native.zip_set_file_compression (archive, (ulong)index, isDir ? CompressionMethod.Store : compressionMethod, 0) < 0)
+			if (Native.zip_set_file_compression (archive, (ulong)index, isDir ? CompressionMethod.Store : compressionMethod, 9) < 0)
 				throw GetErrorException ();
 			PlatformServices.Instance.SetEntryPermissions (this, sourcePath, (ulong)index, permissions);
 			ZipEntry entry = ReadEntry ((ulong)index);


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5971#issuecomment-857279796

Also, attempt to tweak `zlib-ng` to use the best compression possible,
by sacrificing speed.