### PR TITLE
Switch back to zlib instead of zlib-ng

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,7 @@
 	url = https://github.com/xz-mirror/xz.git
 	branch = master
 
+[submodule "zlib"]
+	path = external/zlib
+	url = https://github.com/madler/zlib.git
+	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ cmake_minimum_required(VERSION 3.18)
 option(BUILD_DEPENDENCIES "Build only libzip dependencies" OFF)
 option(BUILD_LIBZIP "Build libzip and libZipSharp" OFF)
 option(ENABLE_XZ "Enable XZ (LZMA compression) in the build" OFF)
+option(ENABLE_ZLIBNG "Use zlib-ng instead of zlib" OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE True CACHE BOOL "Always build position independent code" FORCE)
 
@@ -53,9 +54,11 @@ endif()
 #
 # zlib-ng
 #
-set(ZLIB_COMPAT ON CACHE BOOL "Build zlib-ng for compatibility with zlib" FORCE)
-set(ZLIB_ENABLE_TESTS OFF CACHE BOOL "Do not build zlib-ng tests" FORCE)
-set(WITH_NEW_STRATEGIES OFF CACHE BOOL "Disable faster, but with worse compression, deflate strategies" FORCE)
+if(ENABLE_ZLIBNG)
+  set(ZLIB_COMPAT ON CACHE BOOL "Build zlib-ng for compatibility with zlib" FORCE)
+  set(ZLIB_ENABLE_TESTS OFF CACHE BOOL "Do not build zlib-ng tests" FORCE)
+  set(WITH_NEW_STRATEGIES OFF CACHE BOOL "Disable faster, but with worse compression, deflate strategies" FORCE)
+endif()
 
 #
 # Read product version
@@ -289,7 +292,11 @@ endforeach()
 set(LZS_CXX_LINKER_FLAGS "${_CHECKED_FLAGS}")
 
 if(BUILD_DEPENDENCIES)
-  add_subdirectory(external/zlib-ng)
+  if(ENABLE_ZLIBNG)
+    add_subdirectory(external/zlib-ng)
+  else()
+    add_subdirectory(external/zlib)
+  endif()
 
   target_compile_options(
     zlib
@@ -521,8 +528,14 @@ else()
     endif()
   else()
     if(WIN32)
+      if(ENABLE_ZLIBNG)
+        set(ZLIB_NAME "zlib.lib")
+      else()
+        set(ZLIB_NAME "zlibstatic.lib")
+      endif()
+
       set(LIBS
-        ${ARTIFACTS_ROOT_DIR}/lib/zlib.lib
+        ${ARTIFACTS_ROOT_DIR}/lib/${ZLIB_NAME}
         ${ARTIFACTS_ROOT_DIR}/lib/bz2.lib
         )
 

--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_LibZipSharpNugetVersion>2.0.0-alpha5</_LibZipSharpNugetVersion>
+    <_LibZipSharpNugetVersion>2.0.0-alpha6</_LibZipSharpNugetVersion>
     <_NativeBuildDir>$(MSBuildThisFileDirectory)lzsbuild</_NativeBuildDir>
     <_ExternalDir>$(MSBuildThisFileDirectory)external</_ExternalDir>
     <_MonoPosixNugetVersion>7.0.0-alpha8.21302.6</_MonoPosixNugetVersion>

--- a/native/version.cc
+++ b/native/version.cc
@@ -11,7 +11,11 @@
 constexpr char libzipsharp_version[] = LIBZIPSHARP_VERSION;
 constexpr char libzip_version[] = LIBZIP_VERSION;
 constexpr char libzlib_version[] = ZLIB_VERSION;
+#if defined (ZLIBNG_VERSION)
 constexpr char libzlibng_version[] = ZLIBNG_VERSION;
+#else
+constexpr char libzlibng_version[] = "not used";
+#endif // ndef ZLIBNG_VERSION
 #if defined (HAVE_XZ)
 constexpr char lzma_version[] = LZMA_VERSION_STRING;
 #else

--- a/zlib-changes.patch
+++ b/zlib-changes.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0fe939d..f3ad0ed 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -229,7 +229,7 @@ endif()
+ #============================================================================
+ # Example binaries
+ #============================================================================
+-
++if(False) # lzs: disable-examples
+ add_executable(example test/example.c)
+ target_link_libraries(example zlib)
+ add_test(example example)
+@@ -247,3 +247,4 @@ if(HAVE_OFF64_T)
+     target_link_libraries(minigzip64 zlib)
+     set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+ endif()
++endif()


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/5971#issuecomment-857279796
Context: https://github.com/xamarin/xamarin-android/pull/5971#issuecomment-857635114
Context: https://github.com/zlib-ng/zlib-ng/issues/850
Context: https://github.com/zlib-ng/zlib-ng/wiki/Deflate-config-comparison

`zlib-ng` is mostly about speed and efficiency, however it achieves its
goal by sometimes sacrificing the compression ratio which then affects
Xamarin.Android, the main LibZipSharp consumer.

Add a new `zlib` submodule and switch to using `zlib` by default instead
of `zlib-ng`, while retaining `zlib-ng` as an option.