### PR TITLE
Use a different license tag for nuget generation

### DIFF
--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_LibZipSharpAssemblyVersion>2.0.0</_LibZipSharpAssemblyVersion>
+    <_LibZipSharpAssemblyVersion>2.0.1</_LibZipSharpAssemblyVersion>
     <!--
       Nuget Version. You can append things like -alpha-1 etc to this value.
       But always leave the $(_LibZipSharpAssemblyVersion) value at the start.

--- a/LibZipSharp/libZipSharp.csproj
+++ b/LibZipSharp/libZipSharp.csproj
@@ -43,7 +43,7 @@
         <Owners>Microsoft, Xamarin</Owners>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageProjectUrl>https://github.com/xamarin/LibZipSharp</PackageProjectUrl>
-        <PackageLicenseUrl>https://raw.githubusercontent.com/xamarin/LibZipSharp/master/LICENSE</PackageLicenseUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageTags></PackageTags>
         <PackageOutputPath>$(MSBuildThisFileDirectory)</PackageOutputPath>


### PR DESCRIPTION
The [`<PackageLicenseExpression>`][0] tag must be used to generate
nuget metadata (if the used license is one of those by the [SPDX][1]
project) that's understood by automated license scanning tooling.

Contents of the tag is a [boolean expression][2].

[0]: https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#important-nuget-package-metadata
[1]: https://spdx.org/licenses/
[2]: https://docs.microsoft.com/en-us/nuget/reference/nuspec#license