### PR TITLE
Add a new more complex unit test

### DIFF
--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -315,11 +315,11 @@ namespace Tests {
 		[Test]
 		[NonParallelizable]
 		//[Repeat (100)]
-		public void SimilateXamarinAndroidUsage ([Values (true, false)] bool copyArchive)
+		public void SimilateXamarinAndroidUsage ([Values (true, false)] bool copyArchive, [Values (true, false)] bool useFiles)
 		{
 			string filePath = Path.GetFullPath ("packaged_resources");
 			if (!File.Exists (filePath)) {
-				filePath = Path.GetFullPath (Path.Combine ("LibZipSharp.UnitTest", "packaged_resources"));
+				filePath = Path.GetFullPath (Path.Combine ("/Users/dean/Documents/Sandbox/dellis1972/LibZipSharp/LibZipSharp.UnitTest", "packaged_resources"));
 			}
 
 			if (File.Exists ("base.zip"))
@@ -359,12 +359,17 @@ namespace Tests {
 					byte[] buffer = new byte[fileSize];
 					rnd.NextBytes (buffer);
 					CompressionMethod compression = rnd.NextDouble () < 0.2 ? CompressionMethod.Deflate : CompressionMethod.Store;
-
-					var ms = new MemoryStream (buffer);
-					ms.Position = 0;
 					string entryName = $"temp/file_{i}_size_{fileSize}_{compression}.bin";
 					TestContext.Out.WriteLine ($"Adding {entryName} to base.zip");
-					baseZip.Archive.AddStream (ms, entryName, compressionMethod: compression);
+					if (useFiles) {
+						Directory.CreateDirectory ("temp");
+						File.WriteAllBytes (entryName, buffer);
+						baseZip.Archive.AddFile (entryName, compressionMethod: compression);
+					} else {
+						var ms = new MemoryStream (buffer);
+						ms.Position = 0;
+						baseZip.Archive.AddStream (ms, entryName, compressionMethod: compression);
+					}
 					expectedFiles.Add ((entryName, compression, fileSize));
 
 					if (rnd.NextDouble () < 0.2)

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -258,8 +258,6 @@ namespace Tests {
 		}
 
 		[Test]
-		[NonParallelizable]
-		[Repeat (10)]
 		public void SimilateXamarinAndroidUsage ([Values (true, false)] bool copyArchive, [Values (true, false)] bool useFiles)
 		{
 			string filePath = Path.GetFullPath ("packaged_resources");

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -258,7 +258,7 @@ namespace Tests {
 		}
 
 		[Test]
-		public void SimilateXamarinAndroidUsage ([Values (true, false)] bool copyArchive, [Values (true, false)] bool useFiles)
+		public void SimulateXamarinAndroidUsage ([Values (true, false)] bool copyArchive, [Values (true, false)] bool useFiles)
 		{
 			string filePath = Path.GetFullPath ("packaged_resources");
 			if (!File.Exists (filePath)) {

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -319,7 +319,7 @@ namespace Tests {
 		{
 			string filePath = Path.GetFullPath ("packaged_resources");
 			if (!File.Exists (filePath)) {
-				filePath = Path.GetFullPath (Path.Combine ("/Users/dean/Documents/Sandbox/dellis1972/LibZipSharp/LibZipSharp.UnitTest", "packaged_resources"));
+				filePath = Path.GetFullPath (Path.Combine ("LibZipSharp.UnitTest", "packaged_resources"));
 			}
 
 			if (File.Exists ("base.zip"))

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -314,7 +314,7 @@ namespace Tests {
 
 		[Test]
 		[NonParallelizable]
-		//[Repeat (100)]
+		[Repeat (100)]
 		public void SimilateXamarinAndroidUsage ([Values (true, false)] bool copyArchive, [Values (true, false)] bool useFiles)
 		{
 			string filePath = Path.GetFullPath ("packaged_resources");
@@ -336,19 +336,19 @@ namespace Tests {
 			Random rnd = new Random (3456464);
 
 			using (var baseZip = new ZipWrapper ("base.zip", mode)) {
-				if (!copyArchive) {
-					using (var zip = ZipArchive.Open (filePath, FileMode.Open)) {
-						foreach (var entry in zip) {
-							var entryName = entry.FullName;
-							if (entryName.Contains ("\\")) {
-								entryName = entryName.Replace ('\\', '/');
-							}
-							var ms = new MemoryStream ();
-							entry.Extract (ms);
-							TestContext.Out.WriteLine ($"Adding {entryName} to base.zip");
-							baseZip.Archive.AddStream (ms, entryName, compressionMethod: entry.CompressionMethod);
-							expectedFiles.Add ((entryName, entry.CompressionMethod, entry.Size));
+				using (var zip = ZipArchive.Open (filePath, FileMode.Open)) {
+					foreach (var entry in zip) {
+						var entryName = entry.FullName;
+						if (entryName.Contains ("\\")) {
+							entryName = entryName.Replace ('\\', '/');
 						}
+						expectedFiles.Add ((entryName, entry.CompressionMethod, entry.Size));
+						if (!copyArchive)
+							continue;
+						var ms = new MemoryStream ();
+						entry.Extract (ms);
+						TestContext.Out.WriteLine ($"Adding {entryName} to base.zip");
+						baseZip.Archive.AddStream (ms, entryName, compressionMethod: entry.CompressionMethod);
 					}
 				}
 
@@ -385,6 +385,9 @@ namespace Tests {
 					Assert.AreEqual (file.c, e.CompressionMethod, $"{file} should be {file.c} but was {e.CompressionMethod}.");
 				}
 			}
+
+			if (File.Exists ("base.zip"))
+				File.Delete ("base.zip");
 		}
 
 		[Test]

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -264,7 +264,7 @@ namespace Tests {
 		{
 			string filePath = Path.GetFullPath ("packaged_resources");
 			if (!File.Exists (filePath)) {
-				filePath = Path.GetFullPath (Path.Combine ("/Users/dean/Documents/Sandbox/dellis1972/LibZipSharp/LibZipSharp.UnitTest", "packaged_resources"));
+				filePath = Path.GetFullPath (Path.Combine ("LibZipSharp.UnitTest", "packaged_resources"));
 			}
 
 			string baseArchive = $"base_{copyArchive}_{useFiles}.zip";

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -259,7 +259,7 @@ namespace Tests {
 
 		[Test]
 		[NonParallelizable]
-		[Repeat (100)]
+		[Repeat (10)]
 		public void SimilateXamarinAndroidUsage ([Values (true, false)] bool copyArchive, [Values (true, false)] bool useFiles)
 		{
 			string filePath = Path.GetFullPath ("packaged_resources");

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -319,7 +319,7 @@ namespace Tests {
 		{
 			string filePath = Path.GetFullPath ("packaged_resources");
 			if (!File.Exists (filePath)) {
-				filePath = Path.GetFullPath (Path.Combine ("/Users/dean/Documents/Sandbox/dellis1972/LibZipSharp/LibZipSharp.UnitTest", "packaged_resources"));
+				filePath = Path.GetFullPath (Path.Combine ("LibZipSharp.UnitTest", "packaged_resources"));
 			}
 
 			if (File.Exists ("base.zip"))
@@ -358,7 +358,7 @@ namespace Tests {
 					uint fileSize = (uint)rnd.Next (341, 3535592);
 					byte[] buffer = new byte[fileSize];
 					rnd.NextBytes (buffer);
-					CompressionMethod compression = rnd.NextDouble () < 0.2 ? CompressionMethod.Deflate : CompressionMethod.Store;
+					CompressionMethod compression = rnd.NextDouble () < 0.8 ? CompressionMethod.Deflate : CompressionMethod.Store;
 					string entryName = $"temp/file_{i}_size_{fileSize}_{compression}.bin";
 					TestContext.Out.WriteLine ($"Adding {entryName} to base.zip");
 					if (useFiles) {

--- a/LibZipSharp.UnitTest/ZipWrapper.cs
+++ b/LibZipSharp.UnitTest/ZipWrapper.cs
@@ -1,0 +1,65 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Xamarin.Tools.Zip;
+using Unix = Mono.Unix;
+
+namespace Tests {
+	public class ZipWrapper : IDisposable {
+		ZipArchive archive;
+		string filename;
+		public ZipArchive Archive => archive;
+
+		public ZipWrapper (string file, FileMode mode = FileMode.CreateNew) {
+			filename = file;
+			archive = ZipArchive.Open (filename, mode);
+		}
+
+		public void Flush () {
+			if (archive != null) {
+				archive.Close ();
+				archive.Dispose ();
+				archive = null;
+			}
+			archive = ZipArchive.Open (filename, FileMode.Open);
+		}
+
+		/// <summary>
+		/// HACK: aapt2 is creating zip entries on Windows such as `assets\subfolder/asset2.txt`
+		/// </summary>
+		public void FixupWindowsPathSeparators (Action<string, string> onRename)
+		{
+			bool modified = false;
+			foreach (var entry in archive) {
+				if (entry.FullName.Contains ("\\")) {
+					var name = entry.FullName.Replace ('\\', '/');
+					onRename?.Invoke (entry.FullName, name);
+					entry.Rename (name);
+					modified = true;
+				}
+			}
+			if (modified) {
+				Flush ();
+			}
+		}
+
+		public void Dispose ()
+		{
+			Dispose(true);
+			GC.SuppressFinalize (this);
+		}
+
+		protected virtual void Dispose(bool disposing) {
+			if (disposing) {
+				if (archive != null) {
+					archive.Close ();
+					archive.Dispose ();
+					archive = null;
+				}
+			}
+		}
+	}
+}

--- a/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
@@ -852,8 +852,14 @@ namespace Xamarin.Tools.Zip
 					length = (int)Math.Min (stream.Length - stream.Position, length);
 					buffer = ArrayPool<byte>.Shared.Rent (length);
 					try {
-						int bytesRead = stream.Read (buffer, 0, length);
-						Marshal.Copy (buffer, 0, data, bytesRead);
+						int bytesRead = 0;
+						int startIndex = 0;
+						while (length > 0) {
+							bytesRead = stream.Read (buffer, 0, length);
+							Marshal.Copy (buffer, startIndex, data, bytesRead);
+							startIndex += bytesRead;
+							length -= bytesRead;
+						}
 						return bytesRead;
 					} finally {
 						ArrayPool<byte>.Shared.Return (buffer);


### PR DESCRIPTION
Add a new more complete unit test which emulates how Xamarin.Android uses LibZipSharp.

Also made a small change to the way we handle reading from a stream. According to the documentation `stream.Read` can return a value less than what was asked. So we need to keep reading until we get all the data we expected or an error is thrown.