### PR TITLE
Use RuntimeInformation to determine the Processor architecture.

### DIFF
--- a/LibZipSharp/Xamarin.LibZipSharp.targets
+++ b/LibZipSharp/Xamarin.LibZipSharp.targets
@@ -4,13 +4,13 @@
   </PropertyGroup>
   <ItemGroup>
     <_LibZipNativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\libZipSharpNative.*">
-      <Link>lib64\%(FileName)%(Extension)</Link>
+      <Link>x64\%(FileName)%(Extension)</Link>
     </_LibZipNativeLibs>
     <_LibZipNativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-arm64\native\libZipSharpNative.*">
-      <Link>%(FileName)%(Extension)</Link>
+      <Link>arm64\%(FileName)%(Extension)</Link>
     </_LibZipNativeLibs>
     <_LibZipNativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\win-x86\native\libZipSharpNative.*">
-      <Link>%(FileName)%(Extension)</Link>
+      <Link>x86\%(FileName)%(Extension)</Link>
     </_LibZipNativeLibs>
     <_LibZipNativeLibs Include="$(MSBuildThisFileDirectory)..\runtimes\osx\native\libZipSharpNative.dylib">
       <Link>%(FileName)%(Extension)</Link>

--- a/LibZipSharp/Xamarin.Tools.Zip/Native.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Native.cs
@@ -458,14 +458,14 @@ namespace Xamarin.Tools.Zip
 	#if !NET45
 				string arch = RuntimeInformation.ProcessArchitecture.ToString ().ToLower ();
 				string path = System.IO.Path.Combine (executingDirectory, arch);
+	#else
+				string path = System.IO.Path.Combine (executingDirectory, Environment.Is64BitProcess ? "x64" : "x86"));
+	#endif
 				if (System.IO.Directory.Exists (path)) {
 					SetDllDirectory (path);
 					return;
 				}
 				SetDllDirectory (executingDirectory);
-	#else
-				SetDllDirectory (Environment.Is64BitProcess ? System.IO.Path.Combine (executingDirectory, "x64") : executingDirectory);
-	#endif
 			}
 		}
 	}

--- a/LibZipSharp/Xamarin.Tools.Zip/Native.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Native.cs
@@ -455,7 +455,13 @@ namespace Xamarin.Tools.Zip
 		{
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
 				string executingDirectory = System.IO.Path.GetDirectoryName (typeof(Native).Assembly.Location);
-				SetDllDirectory (Environment.Is64BitProcess ? System.IO.Path.Combine (executingDirectory, "lib64") : executingDirectory);
+				string arch = RuntimeInformation.ProcessArchitecture.ToString ().ToLower ();
+				string path = System.IO.Path.Combine (executingDirectory, arch);
+				if (System.IO.Directory.Exists (path)) {
+					SetDllDirectory (path);
+					return;
+				}
+				SetDllDirectory (executingDirectory);
 			}
 		}
 	}

--- a/LibZipSharp/Xamarin.Tools.Zip/Native.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Native.cs
@@ -459,7 +459,7 @@ namespace Xamarin.Tools.Zip
 				string arch = RuntimeInformation.ProcessArchitecture.ToString ().ToLower ();
 				string path = System.IO.Path.Combine (executingDirectory, arch);
 	#else
-				string path = System.IO.Path.Combine (executingDirectory, Environment.Is64BitProcess ? "x64" : "x86"));
+				string path = System.IO.Path.Combine (executingDirectory, Environment.Is64BitProcess ? "x64" : "x86");
 	#endif
 				if (System.IO.Directory.Exists (path)) {
 					SetDllDirectory (path);

--- a/LibZipSharp/Xamarin.Tools.Zip/Native.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Native.cs
@@ -455,6 +455,7 @@ namespace Xamarin.Tools.Zip
 		{
 			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
 				string executingDirectory = System.IO.Path.GetDirectoryName (typeof(Native).Assembly.Location);
+	#if !NET45
 				string arch = RuntimeInformation.ProcessArchitecture.ToString ().ToLower ();
 				string path = System.IO.Path.Combine (executingDirectory, arch);
 				if (System.IO.Directory.Exists (path)) {
@@ -462,6 +463,9 @@ namespace Xamarin.Tools.Zip
 					return;
 				}
 				SetDllDirectory (executingDirectory);
+	#else
+				SetDllDirectory (Environment.Is64BitProcess ? System.IO.Path.Combine (executingDirectory, "x64") : executingDirectory);
+	#endif
 			}
 		}
 	}


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.architecture?view=net-6.0

Now that we ship an arm based native library on windows we need to be
able to determine the underlying library to load. We can use the
`RuntimeInformation.ProcessArchitecture` value to get this data.

Then based on that we can load from `x86`, `x64` or `arm64` subdirectories.
Note we will still fallback to loading from the current directory , but
the preference is to load from on of the architecture specific sub directories.