### PR TITLE
Bump Mono.Unix to 7.1.0-final.1.21458.1

### DIFF
--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_LibZipSharpAssemblyVersion>2.0.4</_LibZipSharpAssemblyVersion>
+    <_LibZipSharpAssemblyVersion>2.0.5</_LibZipSharpAssemblyVersion>
     <!--
       Nuget Version. You can append things like -alpha-1 etc to this value.
       But always leave the $(_LibZipSharpAssemblyVersion) value at the start.
@@ -8,7 +8,7 @@
     <_LibZipSharpNugetVersion>$(_LibZipSharpAssemblyVersion)</_LibZipSharpNugetVersion>
     <_NativeBuildDir>$(MSBuildThisFileDirectory)lzsbuild</_NativeBuildDir>
     <_ExternalDir>$(MSBuildThisFileDirectory)external</_ExternalDir>
-    <_MonoPosixNugetVersion>7.0.0-final.1.21369.2</_MonoPosixNugetVersion>
+    <_MonoPosixNugetVersion>7.1.0-final.1.21458.1</_MonoPosixNugetVersion>
     <UseXZ Condition=" '$(UseXZ)' == '' ">false</UseXZ>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
It fixes `libc` p/invokes on Unix.  The previous version would try to
resolve them in the `msvcrt` library instead of `libc`