### PR TITLE
[Localization] Add OneLocBuild job

### DIFF
--- a/Localize/LocProject.json
+++ b/Localize/LocProject.json
@@ -1,0 +1,14 @@
+{
+    "Projects": [
+      {
+        "LanguageSet": "VS_Main_Languages",
+        "LocItems": [
+          {
+            "CopyOption": "LangIDOnName",
+            "SourceFile": ".\\LibZipSharp\\Properties\\Resources.resx",
+            "OutputPath": ".\\LibZipSharp\\Properties"
+          }
+        ]
+      }
+    ]
+  }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,7 +270,7 @@ stages:
 
   - stage: Localization
     dependsOn: []
-    condition: and(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/oneloc'))
+    condition: and(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
     jobs:
     - job: OneLocBuild
       displayName: OneLocBuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -257,8 +257,8 @@ stages:
           displayName: "Run Tests under .net Core"
           inputs:
             command: test
-            arguments: 'LibZipSharp.UnitTest\bin\Release\netcoreapp3.1\LibZipSharp.UnitTest.dll
-'
+            arguments: 'LibZipSharp.UnitTest\bin\Release\netcoreapp3.1\LibZipSharp.UnitTest.dll'
+
   - stage: Publish
     dependsOn: Test
     condition: eq(variables['System.TeamProject'], 'devdiv') # only sign the packages when running on Windows, and using the private server which has the certificates
@@ -267,3 +267,43 @@ stages:
       parameters:
         signListPath: 'SignList.xml'
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+
+  - stage: Localization
+    dependsOn: []
+    condition: and(eq(variables['System.TeamProject'], 'DevDiv'), eq(variables['Build.SourceBranch'], 'refs/heads/dev/pjc/oneloc'))
+    jobs:
+    - job: OneLocBuild
+      displayName: OneLocBuild
+      pool: VSEngSS-MicroBuild2022-1ES
+      timeoutInMinutes: 30
+      variables:
+      - group: Xamarin-Secrets
+      workspace:
+        clean: all
+      steps:
+      - checkout: self
+        clean: true
+
+      - task: OneLocBuild@2
+        displayName: OneLocBuild
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        inputs:
+          locProj: Localize/LocProject.json
+          outDir: $(Build.StagingDirectory)
+          packageSourceAuth: patAuth
+          patVariable: $(OneLocBuild--PAT)
+          isCreatePrSelected: true
+          repoType: gitHub
+          gitHubPatVariable: $(github--pat--vs-mobiletools-engineering-service2)
+          prSourceBranchPrefix: locpr
+          isShouldReusePrSelected: true
+          isAutoCompletePrSelected: false
+          isUseLfLineEndingsSelected: true
+
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Localization Files
+        inputs:
+          PathtoPublish: $(Build.StagingDirectory)/loc
+          ArtifactName: Loc
+        condition: succeededOrFailed()


### PR DESCRIPTION
A new job has been added to run the `OneLocBuild@2` task on every commit
to main.  This task produces files needed by the localization team.  For
more details on this process, see the [OneLocBuild documentation][0].

[0]: https://aka.ms/OneLocBuild