### PR TITLE
Bump Microsoft.NET.Test.Sdk  to 17.4.1

### DIFF
--- a/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
+++ b/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Xamarin.LibZipSharp" Version="$(_LibZipSharpNugetVersion)" Condition="'$(ReferenceNuget)' == 'True'" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="Mono.Unix" Version="$(_MonoPosixNugetVersion)" />


### PR DESCRIPTION
Context https://i.azdo.io/1716020

Bump the Microsoft.NET.Test.Sdk  to latest stable as the currentl version pulls in an old version of
NewtonSoft.Json