### PR TITLE
Updates to match new libzip version + potential fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,10 +459,18 @@ else()
   add_library(
     ${PROJECT_NAME}
     SHARED
+    native/sizes.cc
+    native/values.cc
     native/version.cc
     )
 
   add_dependencies(${PROJECT_NAME} zip)
+
+  target_include_directories(
+    ${PROJECT_NAME}
+    PRIVATE
+    "external/libzip/lib"
+  )
 
   target_compile_definitions(
     ${PROJECT_NAME}

--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_LibZipSharpAssemblyVersion>2.0.8</_LibZipSharpAssemblyVersion>
+    <_LibZipSharpAssemblyVersion>2.1.0</_LibZipSharpAssemblyVersion>
     <!--
       Nuget Version. You can append things like -alpha-1 etc to this value.
       But always leave the $(_LibZipSharpAssemblyVersion) value at the start.

--- a/LibZipSharp/Xamarin.Tools.Zip/EncryptionMethod.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/EncryptionMethod.cs
@@ -45,57 +45,90 @@ namespace Xamarin.Tools.Zip
 
 		/// <summary>
 		/// Strong encryption: DES
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
 		/// </summary>
 		DES             = 0x6601,
 
 		/// <summary>
 		/// Strong encryption: RC2, version &lt; 5.2
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
 		/// </summary>
 		RC2_Old         = 0x6602,
 
 		/// <summary>
 		/// Strong encryption: 3DES (168-bit key)
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
 		/// </summary>
 		Three_DES_168   = 0x6603,
 
 		/// <summary>
 		/// Strong encryption: 3DES (112-bit key)
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
 		/// </summary>
 		Three_DES_112   = 0x6609,
 
 		/// <summary>
-		/// Strong encryption: AES (128-bit key)
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// Strong encryption: PKZIP AES (128-bit key)
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
 		/// </summary>
-		AES_128         = 0x660e,
+		PKZIP_AES_128    = 0x660e,
 
 		/// <summary>
-		/// Strong encryption: AES (192-bit key)
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// Deprecated alias for <see cref="AES_128"/>
 		/// </summary>
-		AES_192         = 0x660f,
+		[Obsolete ("Use EncryptionMethod.PKZIP_AES_128")]
+		AES_128          = PKZIP_AES_128,
+
+		/// <summary>
+		/// Strong encryption: PKZIP AES (192-bit key)
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
+		/// </summary>
+		PKZIP_AES_192    = 0x660f,
+
+		/// <summary>
+		/// Deprecated alias for <see cref="AES_192"/>
+		/// </summary>
+		[Obsolete ("Use EncryptionMethod.PKZIP_AES_192")]
+		AES_192          = PKZIP_AES_192,
 
 		/// <summary>
 		/// Strong encryption: AES (256-bit key)
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
 		/// </summary>
-		AES_256         = 0x6610,
+		PKZIP_AES_256    = 0x6610,
+
+		/// <summary>
+		/// Deprecated alias for <see cref="AES_256"/>
+		/// </summary>
+		[Obsolete ("Use EncryptionMethod.PKZIP_AES_256")]
+		AES_256          = PKZIP_AES_256,
 
 		/// <summary>
 		/// Strong encryption: RC2, version >= 5.2
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
 		/// </summary>
 		RC2             = 0x6702,
 
 		/// <summary>
 		/// Strong encryption: RC4
-		/// <remarks>Not supported by the native libzip yet (as of v1.0.1)</remarks>
+		/// <remarks>Not supported by the native libzip yet (as of v1.9.2)</remarks>
 		/// </summary>
 		RC4             = 0x6801,
+
+		/// <summary>
+		/// WinZIP AES encryption (128-bit key)
+		/// </summary>
+		WINZIP_AES_128  = 0x0101,
+
+		/// <summary>
+		/// WinZIP AES encryption (192-bit key)
+		/// </summary>
+		WINZIP_AES_192  = 0x0102,
+
+		/// <summary>
+		/// WinZIP AES encryption (256-bit key)
+		/// </summary>
+		WINZIP_AES_256  = 0x0103,
 
 		/// <summary>
 		/// Unknown algorithm
@@ -103,4 +136,3 @@ namespace Xamarin.Tools.Zip
 		Unknown         = 0xffff,
 	}
 }
-

--- a/LibZipSharp/Xamarin.Tools.Zip/EntryPermissions.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/EntryPermissions.cs
@@ -26,11 +26,11 @@
 using System;
 namespace Xamarin.Tools.Zip
 {
-	[Flags]
 	/// <summary>
 	/// ZIP (as opposed to filesystem) entry permission bits. The bits are used only
 	/// on the Unix systems.
 	/// </summary>
+	[Flags]
 	public enum EntryPermissions : uint
 	{
 		Default = 0,
@@ -55,4 +55,3 @@ namespace Xamarin.Tools.Zip
 		SetDirectoryPermissionControl = UnixExternalPermissions.ISVTX,
 	}
 }
-

--- a/LibZipSharp/Xamarin.Tools.Zip/ErrorCode.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ErrorCode.cs
@@ -192,5 +192,15 @@ namespace Xamarin.Tools.Zip
 		/// Tell error
 		/// </summary>
 		Tell           = 30,
+
+		/// <summary>
+		/// Compressed data invalid
+		/// </summary>
+		CompressedData = 31,
+
+		/// <summary>
+		/// Operation cancelled
+		/// </summary>
+		Cancelled      = 32,
 	}
 }

--- a/LibZipSharp/Xamarin.Tools.Zip/ErrorType.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ErrorType.cs
@@ -46,6 +46,10 @@ namespace Xamarin.Tools.Zip
 		/// Error code field is zlib error code
 		/// </summary>
 		Zlib           = 2,
+
+		/// <summary>
+		/// Error code field is libzip error code
+		/// </summary>
+		Libzip         = 3,
 	}
 }
-

--- a/LibZipSharp/Xamarin.Tools.Zip/IPlatformServices.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/IPlatformServices.cs
@@ -23,7 +23,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-using System;
 using System.Collections.Generic;
 
 namespace Xamarin.Tools.Zip
@@ -37,8 +36,10 @@ namespace Xamarin.Tools.Zip
 		/// Checks whether the filesystem location identified by <paramref name="path"/> is a regular
 		/// file. Irregular files include device nodes, sockets, character or block devices on Unix systems etc.
 		/// </summary>
-		/// <returns><c>true</c> if <paramref name="path"/> points to regular file</returns>
+		/// <returns><c>true</c> if operation was successful, <c>false</c> otherwise</returns>
+		/// <param name="archive">ZipArchive to operate on</param>
 		/// <param name="path">Path to the filesystem location</param>
+		/// <param name="result"><c>true</c> if <paramref name="path"/> points to regular file</param>
 		bool IsRegularFile (ZipArchive archive, string path, out bool result);
 		bool IsDirectory (ZipArchive archive, string path, out bool result);
 		bool GetFilesystemPermissions (ZipArchive archive, string path, out EntryPermissions permissions);

--- a/LibZipSharp/Xamarin.Tools.Zip/Native.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Native.cs
@@ -99,9 +99,19 @@ namespace Xamarin.Tools.Zip
 			return 1 << (int)cmd;
 		}
 
-		public static T ZipSourceGetArgs<T> (IntPtr data, UInt64 len)
+		public unsafe static bool ZipSourceGetArgs<T> (IntPtr data, UInt64 len, out T ret) where T : unmanaged
 		{
-			return (T)Marshal.PtrToStructure (data, typeof (T));
+			ret = default(T);
+			if (data == IntPtr.Zero) {
+				return false;
+			}
+
+			if (len < (ulong)sizeof (T)) {
+				return false;
+			}
+
+			ret = (T)Marshal.PtrToStructure (data, typeof (T));
+			return true;
 		}
 
 		const string ZIP_LIBNAME = "libZipSharpNative";

--- a/LibZipSharp/Xamarin.Tools.Zip/Native.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Native.cs
@@ -25,6 +25,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 
 [assembly: DefaultDllImportSearchPathsAttribute(DllImportSearchPath.SafeDirectories | DllImportSearchPath.AssemblyDirectory)]
@@ -33,6 +34,11 @@ namespace Xamarin.Tools.Zip
 {
 	internal class Native
 	{
+		const UInt32 LZS_SEEK_SET     = 0;
+		const UInt32 LZS_SEEK_CUR     = 1;
+		const UInt32 LZS_SEEK_END     = 2;
+		const UInt32 LZS_SEEK_INVALID = 0xDEADBEEFu;
+
 		[StructLayout (LayoutKind.Sequential)]
 		public struct LZSVersions
 		{
@@ -53,6 +59,7 @@ namespace Xamarin.Tools.Zip
 			public IntPtr str;							/* string representation or NULL */
 		};
 
+		[StructLayout (LayoutKind.Sequential)]
 		public struct zip_source_args_seek_t
 		{
 			public UInt64 offset;
@@ -101,6 +108,29 @@ namespace Xamarin.Tools.Zip
 
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
 		static extern void lzs_get_versions (out LZSVersions versions);
+
+		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt64 lzs_get_size_zip_source_args_seek ();
+
+		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
+		public static extern UInt32 lzs_convert_whence_value (Int32 whence);
+
+		public static SeekOrigin ConvertWhence (Int32 whence)
+		{
+			switch (lzs_convert_whence_value (whence)) {
+				case LZS_SEEK_SET:
+					return SeekOrigin.Begin;
+
+				case LZS_SEEK_CUR:
+					return SeekOrigin.Current;
+
+				case LZS_SEEK_END:
+					return SeekOrigin.End;
+
+				default:
+					throw new InvalidOperationException ($"Invalid whence value: {whence}");
+			}
+		}
 
 		public static Versions get_versions ()
 		{
@@ -208,10 +238,36 @@ namespace Xamarin.Tools.Zip
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int zip_stat_index (IntPtr archive, UInt64 index, OperationFlags flags, out zip_stat_t sb);
 
+		static void StringToComment (string comment, out IntPtr utfString, out UInt16 len)
+		{
+			if (comment == null) {
+				utfString = IntPtr.Zero;
+				len = 0;
+				return;
+			}
+
+			utfString = Utilities.StringToUtf8StringPtr (comment, out int count);
+			len = count > UInt16.MaxValue ? UInt16.MaxValue : (UInt16)count;
+		}
+
+		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int zip_file_set_comment (IntPtr archive, UInt64 index, IntPtr comment, UInt16 len, OperationFlags flags);
+
+		public static int zip_file_set_comment (IntPtr archive, UInt64 index, string comment)
+		{
+			StringToComment (comment, out IntPtr utfComment, out UInt16 len);
+
+			try {
+				return zip_file_set_comment (archive, index, utfComment, len, OperationFlags.Enc_UTF_8);
+			} finally {
+				Utilities.FreeUtf8StringPtr (utfComment);
+			}
+		}
+
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl, EntryPoint="zip_file_get_comment")]
 		public static extern IntPtr zip_file_get_comment_ptr (IntPtr archive, UInt64 index, out UInt32 lenp, OperationFlags flags);
 
-		public static string zip_file_get_comment (IntPtr archive, UInt64 index, out UInt32 lenp, OperationFlags flags)
+		public static string zip_file_get_comment (IntPtr archive, UInt64 index, out UInt32 lenp, OperationFlags flags = OperationFlags.Enc_Guess)
 		{
 			return Utilities.Utf8StringPtrToString (zip_file_get_comment_ptr (archive, index, out lenp, flags));
 		}
@@ -219,9 +275,23 @@ namespace Xamarin.Tools.Zip
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl, EntryPoint="zip_get_archive_comment")]
 		public static extern IntPtr zip_get_archive_comment_ptr (IntPtr archive, out int lenp, OperationFlags flags);
 
-		public static string zip_get_archive_comment (IntPtr archive, out int lenp, OperationFlags flags)
+		public static string zip_get_archive_comment (IntPtr archive, OperationFlags flags = OperationFlags.Enc_Guess)
 		{
-			return Utilities.Utf8StringPtrToString (zip_get_archive_comment_ptr (archive, out lenp, flags));
+			return Utilities.Utf8StringPtrToString (zip_get_archive_comment_ptr (archive, out int _, flags));
+		}
+
+		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
+		public static extern int zip_set_archive_comment (IntPtr archive, IntPtr comment, UInt16 len);
+
+		public static int zip_set_archive_comment (IntPtr archive, string comment)
+		{
+			StringToComment (comment, out IntPtr utfComment, out UInt16 len);
+
+			try {
+				return zip_set_archive_comment (archive, utfComment, len);
+			} finally {
+				Utilities.FreeUtf8StringPtr (utfComment);
+			}
 		}
 
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
@@ -242,13 +312,13 @@ namespace Xamarin.Tools.Zip
 		public static extern int zip_set_default_password (IntPtr archive, string password);
 
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int zip_rename (IntPtr archive, UInt64 index, IntPtr name);
+		public static extern int zip_file_rename (IntPtr archive, UInt64 index, IntPtr name, OperationFlags flags);
 
-		public static int zip_rename (IntPtr archive, UInt64 index, string name)
+		public static int zip_file_rename (IntPtr archive, UInt64 index, string name)
 		{
 			var utfName = Utilities.StringToUtf8StringPtr (name);
 			try {
-				return zip_rename (archive, index, utfName);
+				return zip_file_rename (archive, index, utfName, OperationFlags.Enc_UTF_8);
 			} finally {
 				Utilities.FreeUtf8StringPtr (utfName);
 			}
@@ -386,19 +456,6 @@ namespace Xamarin.Tools.Zip
 
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int zip_file_replace (IntPtr archive, UInt64 index, IntPtr source, OperationFlags flags);
-
-		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int zip_set_file_comment (IntPtr archive, UInt64 index, IntPtr comment, UInt16 len, OperationFlags flags);
-
-		public static int zip_set_file_comment (IntPtr archive, UInt64 index, string comment, UInt16 len, OperationFlags flags)
-		{
-			IntPtr utfComment = Utilities.StringToUtf8StringPtr (comment);
-			try {
-				return zip_set_file_comment (archive, index, utfComment, len, flags);
-			} finally {
-				Utilities.FreeUtf8StringPtr (utfComment);
-			}
-		}
 
 		[DllImport (ZIP_LIBNAME, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int zip_set_file_compression (IntPtr archive, UInt64 index, CompressionMethod comp, UInt32 comp_flags);

--- a/LibZipSharp/Xamarin.Tools.Zip/SourceCommand.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/SourceCommand.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Tools.Zip
 	/// Commands sent to user-defined ZIP source callback function/method. Enumeration
 	/// members correspond to the members of the <c>zip_source_cmd</c> enum defined in
 	/// the <c>zip.h</c> header file (the <c>ZIP_SOURCE_*</c> symbols).
+	///
+	/// <remarks>Order of members MUST be the same as in the C enum</remarks>
 	/// </summary>
 	public enum SourceCommand
 	{
@@ -112,6 +114,26 @@ namespace Xamarin.Tools.Zip
 		/// <summary>
 		/// Remove the underlying file. This is called if a zip archive is empty when closed.
 		/// </summary>
-		Remove
+		Remove,
+
+		/// <summary>
+		/// Previously used internally
+		/// </summary>
+		Reserved1,
+
+		/// <summary>
+		/// Like <see cref="BeginWrite"/>, but keep part of original file
+		/// </summary>
+		BeginWriteCloning,
+
+		/// <summary>
+		/// Whether empty files are valid archives
+		/// </summary>
+		AcceptEmpty,
+
+		/// <summary>
+		/// Get additional file attributes
+		/// </summary>
+		GetFileAttributes,
 	}
 }

--- a/LibZipSharp/Xamarin.Tools.Zip/UnixPlatformServices.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/UnixPlatformServices.cs
@@ -408,8 +408,8 @@ namespace Xamarin.Tools.Zip
 			// would really mean just 64-bit values). The casts below are thus slightly unsafer, but I
 			// don't really think it matters that much...
 			//
-			uint uid = entry.UID.HasValue ? (uint)entry.UID : unchecked((uint)-1);
-			uint gid = entry.GID.HasValue ? (uint)entry.GID : unchecked((uint)-1);
+			int uid = entry.UID.HasValue ? (int)entry.UID : -1;
+			int gid = entry.GID.HasValue ? (int)entry.GID : -1;
 			if (Syscall.chown (extractedFilePath, uid, gid) < 0) {
 				// TODO: log it properly
 				var archive = entry.Archive as UnixZipArchive;

--- a/LibZipSharp/Xamarin.Tools.Zip/Utilities.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Utilities.cs
@@ -122,11 +122,16 @@ namespace Xamarin.Tools.Zip
 
 		public unsafe static IntPtr StringToUtf8StringPtr (string str)
 		{
+			return StringToUtf8StringPtr (str, out int _);
+		}
+
+		public unsafe static IntPtr StringToUtf8StringPtr (string str, out int count)
+		{
 			if (str == null)
 				throw new ArgumentNullException (nameof (str));
 
 			var encoding = Encoding.UTF8;
-			int count = encoding.GetByteCount (str);
+			count = encoding.GetByteCount (str);
 			IntPtr memory = Marshal.AllocHGlobal (count + 1);
 			fixed (char *pStr = str)
 				encoding.GetBytes (pStr, str.Length, (byte*)memory, count);
@@ -162,4 +167,3 @@ namespace Xamarin.Tools.Zip
 		}
 	}
 }
-

--- a/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/ZipArchive.cs
@@ -74,8 +74,27 @@ namespace Xamarin.Tools.Zip
 			get { return Native.zip_get_num_entries (archive, OperationFlags.None); }
 		}
 
+		/// <summary>
+		/// Get or set the archive comment.  If <c>null</c> is passed when setting, comment is removed
+		/// from the archive.
+		/// </summary>
+		public string Comment {
+			get => Native.zip_get_archive_comment (archive);
+			set {
+				if (Native.zip_set_archive_comment (archive, value) != 0) {
+					throw GetErrorException ();
+				}
+			}
+		}
+
+		/// <summary>
+		/// Get options used when the archive was opened/created.
+		/// </summary>
 		public IPlatformOptions Options { get; private set; }
 
+		/// <summary>
+		/// Called before and after each entry is extracted.
+		/// </summary>
 		public event EventHandler<EntryExtractEventArgs> EntryExtract;
 
 		internal ZipArchive (string defaultExtractionDir, IPlatformOptions options)
@@ -196,12 +215,13 @@ namespace Xamarin.Tools.Zip
 		/// <paramref name="mode"/> parameter. If <paramref name="strictConsistencyChecks"/> is <c>true</c>
 		/// some extra checks will be performed on the ZIP being opened. If <paramref name="defaultExtractionDir"/> is
 		/// not <c>null</c> or empty it is used by default by all the entries as the destination directory. Otherwise the
-		/// current directory is used as the destination. Output directory can be different for each entry, see <see cref="ZipEntry.Extract"/>
+		/// current directory is used as the destination. Output directory can be different for each entry, see <see cref="ZipEntry.Extract(string, string, FileMode, bool, string)"/>
 		/// </summary>
 		/// <param name="path">Path to the ZIP archive.</param>
 		/// <param name="mode">File open mode.</param>
 		/// <param name="defaultExtractionDir">default target directory</param>
 		/// <param name="strictConsistencyChecks">Perform strict consistency checks.</param>
+		/// <param name="options">Platform-specific options, or <c>null</c> if none necessary (the default)</param>
 		/// <returns>Opened ZIP archive</returns>
 		public static ZipArchive Open (string path, FileMode mode, string defaultExtractionDir = null, bool strictConsistencyChecks = false, IPlatformOptions options = null)
 		{
@@ -325,6 +345,7 @@ namespace Xamarin.Tools.Zip
 		/// <param name="permissions">The permissions which the stream should have when extracted (Unix Only)</param>
 		/// <param name="compressionMethod">The compression method to use</param>
 		/// <param name="overwriteExisting">If true an existing entry will be overwritten. If false and an existing entry exists and error will be raised</param>
+		/// <param name="modificationTime">Set the entry's modification time to this value, if not <c>null</c>. Defaults to <c>null</c></param>
 		public ZipEntry AddStream (Stream stream, string archivePath, EntryPermissions permissions = EntryPermissions.Default, CompressionMethod compressionMethod = CompressionMethod.Default, bool overwriteExisting = true, DateTime? modificationTime = null)
 		{
 			if (stream == null)
@@ -371,17 +392,17 @@ namespace Xamarin.Tools.Zip
 		/// <param name="overwriteExisting">If set to <c>true</c> overwrite existing entry in the archive.</param>
 		/// <param name="useFileDirectory">If set to <c>true</c> use file directory part.</param>
 		public ZipEntry AddFileToDirectory (string sourcePath, string archiveDirectory = null,
-											EntryPermissions permissions = EntryPermissions.Default,
-											CompressionMethod compressionMethod = CompressionMethod.Default,
-											bool overwriteExisting = true, bool useFileDirectory = true)
+		                                    EntryPermissions permissions = EntryPermissions.Default,
+		                                    CompressionMethod compressionMethod = CompressionMethod.Default,
+		                                    bool overwriteExisting = true, bool useFileDirectory = true)
 		{
 			if (String.IsNullOrEmpty (sourcePath))
 				throw new ArgumentException (string.Format (Resources.MustNotBeNullOrEmpty_string, nameof (sourcePath)), nameof (sourcePath));
 			string destDir = NormalizeArchivePath (true, archiveDirectory);
 			string destFile = useFileDirectory ? GetRootlessPath (sourcePath) : Path.GetFileName (sourcePath);
 			return AddFile (sourcePath,
-					String.IsNullOrEmpty (destDir) ? null : destDir + "/" + destFile,
-					permissions, compressionMethod, overwriteExisting);
+			                String.IsNullOrEmpty (destDir) ? null : destDir + "/" + destFile,
+			                permissions, compressionMethod, overwriteExisting);
 		}
 
 		/// <summary>
@@ -399,9 +420,9 @@ namespace Xamarin.Tools.Zip
 		/// <param name="compressionMethod">Compression method.</param>
 		/// <param name="overwriteExisting">Overwrite existing entries in the archive.</param>
 		public ZipEntry AddFile (string sourcePath, string archivePath = null,
-								 EntryPermissions permissions = EntryPermissions.Default,
-								 CompressionMethod compressionMethod = CompressionMethod.Default,
-								 bool overwriteExisting = true)
+		                         EntryPermissions permissions = EntryPermissions.Default,
+		                         CompressionMethod compressionMethod = CompressionMethod.Default,
+		                         bool overwriteExisting = true)
 		{
 			if (String.IsNullOrEmpty (sourcePath))
 				throw new ArgumentException (string.Format (Resources.MustNotBeNullOrEmpty_string, nameof (sourcePath)), nameof (sourcePath));
@@ -426,10 +447,12 @@ namespace Xamarin.Tools.Zip
 			PlatformServices.Instance.SetEntryPermissions (this, sourcePath, (ulong)index, permissions);
 			ZipEntry entry = ReadEntry ((ulong)index);
 			IList<ExtraField> fields = new List<ExtraField> ();
-			ExtraField_ExtendedTimestamp timestamp = new ExtraField_ExtendedTimestamp (entry, 0,
+			ExtraField_ExtendedTimestamp timestamp = new ExtraField_ExtendedTimestamp (
+				entry, 0,
 				createTime: File.GetCreationTimeUtc (sourcePath),
 				accessTime: File.GetLastAccessTimeUtc (sourcePath),
-				modificationTime: File.GetLastWriteTimeUtc (sourcePath));
+				modificationTime: File.GetLastWriteTimeUtc (sourcePath)
+			);
 			fields.Add (timestamp);
 			if (!PlatformServices.Instance.WriteExtraFields (this, entry, fields))
 				throw GetErrorException ();
@@ -802,6 +825,7 @@ namespace Xamarin.Tools.Zip
 						ArrayPool<byte>.Shared.Return (buffer);
 					}
 
+				// TODO: we should use the passed args, without zip_source_seek_compute_offset
 				case SourceCommand.SeekWrite:
 					Native.zip_error_t error;
 					Int64 offset = Native.zip_source_seek_compute_offset ((UInt64)destination.Position, (UInt64)destination.Length, data, len, out error);
@@ -812,6 +836,7 @@ namespace Xamarin.Tools.Zip
 						return -1;
 					}
 					break;
+
 				case SourceCommand.Seek:
 					offset = Native.zip_source_seek_compute_offset ((UInt64)stream.Position, (UInt64)stream.Length, data, len, out error);
 					if (offset < 0) {
@@ -920,6 +945,7 @@ namespace Xamarin.Tools.Zip
 				default:
 					break;
 			}
+
 			return 0;
 		}
 
@@ -991,4 +1017,3 @@ namespace Xamarin.Tools.Zip
 		}
 	}
 }
-

--- a/native/helpers.hh
+++ b/native/helpers.hh
@@ -1,0 +1,17 @@
+#if !defined (__LZS_HELPERS_HH)
+#define __LZS_HELPERS_HH
+
+#include <cstdlib>
+#include <cstdint>
+
+#if defined(_MSC_VER)
+#define LZS_API __declspec(dllexport)
+#else
+#if defined (__clang__) || defined (__GNUC__)
+#define LZS_API __attribute__ ((__visibility__ ("default")))
+#else
+#define LZS_API
+#endif
+#endif
+
+#endif // __LZS_HELPERS_HH

--- a/native/sizes.cc
+++ b/native/sizes.cc
@@ -1,0 +1,8 @@
+#include <zip.h>
+
+#include "sizes.hh"
+
+uint64_t lzs_get_size_zip_source_args_seek ()
+{
+	return static_cast<uint64_t>(sizeof (zip_source_args_seek_t));
+}

--- a/native/sizes.hh
+++ b/native/sizes.hh
@@ -1,0 +1,9 @@
+#if !defined (__LZS_SIZES_HH)
+#define __LZS_SIZES_HH
+
+#include "helpers.hh"
+
+extern "C" {
+	LZS_API uint64_t lzs_get_size_zip_source_args_seek ();
+}
+#endif // __LZS_SIZES_HH

--- a/native/values.cc
+++ b/native/values.cc
@@ -1,0 +1,20 @@
+#include <cstdio>
+
+#include "values.hh"
+
+uint32_t lzs_convert_whence_value (int32_t whence)
+{
+	switch (whence) {
+		case SEEK_SET:
+			return LZS_SEEK_SET;
+
+		case SEEK_CUR:
+			return LZS_SEEK_CUR;
+
+		case SEEK_END:
+			return LZS_SEEK_END;
+
+		default:
+			return LZS_SEEK_INVALID;
+	}
+}

--- a/native/values.hh
+++ b/native/values.hh
@@ -1,0 +1,15 @@
+#if !defined (__LZS_VALUES_HH)
+#define __LZS_VALUES_HH
+
+#include "helpers.hh"
+
+// Values here must be identical to those in LibZipSharp/Xamarin.Tools.Zip/Native.cs
+constexpr uint32_t LZS_SEEK_SET     = 0;
+constexpr uint32_t LZS_SEEK_CUR     = 1;
+constexpr uint32_t LZS_SEEK_END     = 2;
+constexpr uint32_t LZS_SEEK_INVALID = 0xDEADBEEF;
+
+extern "C" {
+	LZS_API uint32_t lzs_convert_whence_value (int32_t whence);
+}
+#endif // __LZS_VALUES_HH

--- a/native/version.hh
+++ b/native/version.hh
@@ -1,15 +1,7 @@
 #if !defined (__LZS_NATIVE_VERSION_HH)
 #define __LZS_NATIVE_VERSION_HH
 
-#if defined(_MSC_VER)
-#define LZS_API __declspec(dllexport)
-#else
-#if defined (__clang__) || defined (__GNUC__)
-#define LZS_API __attribute__ ((__visibility__ ("default")))
-#else
-#define LZS_API
-#endif
-#endif
+#include "helpers.hh"
 
 struct LZSVersions
 {


### PR DESCRIPTION
A handful of changes for new libzip:

  * Update various enums to add new members from libzip 1.9.2
  * Add support for entry and archive comments
  * Set default values for various methods to match the upstream defaults
  * Stop using deprecated upstream functions

Implement a possible fix for the dreaded "cannot open file as zip archive" error we
sometimes see on CI.  The error is caused by invalid content of the APK we generate
while building a Xamarin.Android app.  During that process we open a ZIP archive 
created by the Android SDK `aapt2` utility and we append our content to it.  In most
cases it works fine, but sometimes (we have no repro for this) the appended content
is invalid.  What we see is that where there should be the content (compressed data
stream) of the **first** file we append to the original archive, there instead is a
copy of that original archive's central directory.

The issue **may** be caused by incorrect handling of the `ZIP_SOURCE_SEEK_WRITE` command
passed to our stream/source handler.  Attempt to fix it by implementing the command
in the manner similar to that found in `libzip` itself.