### PR TITLE
[CMake] Add /PROFILE to MSVC link flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,7 @@ else()
     target_link_options(
       ${PROJECT_NAME}
       PRIVATE
+      /PROFILE
       /wholearchive:$<TARGET_FILE:zip>
       )
   endif()


### PR DESCRIPTION
Context: https://eng.ms/docs/products/apiscan/howto/preparinginput/binaries/creating_vulcan_ready_files

Adds the /PROFILE flag to appease API Scan and produce "vulcan ready"
files.