### PR TITLE
[ci] Improve binskim scan performance

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,8 @@ extends:
     sdl:
       ${{ if eq('${{ parameters.Skip1ESComplianceTasks }}', 'true') }}:
         enableAllTools: false
+      binskim:
+        scanOutputDirectoryOnly: true
       codeql:
         runSourceLanguagesInSourceAnalysis: true
       suppression:


### PR DESCRIPTION
Context: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/binskim#limiting-binskim-to-output-directory-in-sdl-binary-analysis

Attempts to speed up artifact publishing steps by telling `binskim` to
only scan the directory that contains the artifacts being uploaded.