### PR TITLE
Remove LZMA (XZ) support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,9 +12,6 @@
 	path = external/bzip2
 	url = https://sourceware.org/git/bzip2.git
 	branch = master
-[submodule "external/xz"]
-	path = external/xz
-	url = https://github.com/tukaani-project/xz
 [submodule "zlib"]
 	path = external/zlib
 	url = https://github.com/madler/zlib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.18)
 #
 # TODO:
 #
-#  * Windows: use vcpkg to build bzip2 and lzma (vcpkg can be used as a cmake subproject)
+#  * Windows: use vcpkg to build bzip2 (vcpkg can be used as a cmake subproject)
 #  * Include portions of Mono.Posix native code (if necessary and when the new Mono.Posix is ready)
 #  * Add support Android builds
 #  * Add support for iOS/tvOS/macCatalyst builds
@@ -12,7 +12,6 @@ cmake_minimum_required(VERSION 3.18)
 
 option(BUILD_DEPENDENCIES "Build only libzip dependencies" OFF)
 option(BUILD_LIBZIP "Build libzip and libZipSharp" OFF)
-option(ENABLE_XZ "Enable XZ (LZMA compression) in the build" OFF)
 option(ENABLE_ZLIBNG "Use zlib-ng instead of zlib" OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE True CACHE BOOL "Always build position independent code" FORCE)
@@ -22,7 +21,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE True CACHE BOOL "Always build position indep
 #
 
 #
-# libzip, zlib-ng, xz
+# libzip, zlib-ng
 #
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build only as a static library" FORCE)
 
@@ -47,10 +46,6 @@ set(ENABLE_OPENSSL OFF CACHE BOOL "Do not use OpenSSL for libzip" FORCE)
 set(ENABLE_MBEDTLS OFF CACHE BOOL "Do not use mbedtls for libzip" FORCE)
 set(ENABLE_WINDOWS_CRYPTO OFF CACHE BOOL "Do not use Windows Crypto" FORCE)
 set(ENABLE_ZSTD ON CACHE BOOL "Use zstd in libzip" FORCE)
-
-if(NOT ENABLE_XZ)
-  set(ENABLE_LZMA OFF CACHE BOOL "Do not use XZ for libzip" FORCE)
-endif()
 
 #
 # zstd
@@ -345,17 +340,6 @@ if(BUILD_DEPENDENCIES)
     "${ZLIB_EXTERN}"
     )
 
-if(NOT WIN32 AND ENABLE_XZ)
-  add_subdirectory(external/xz)
-
-  target_compile_options(
-    liblzma
-    PRIVATE
-    ${LZS_C_FLAGS}
-    -fvisibility=hidden
-    )
-endif()
-
   add_subdirectory(external/zstd/build/cmake)
   if(UNIX)
     set(ZSTD_EXTERN "-DZSTDLIB_VISIBILITY=__attribute__((visibility(\"hidden\")))")
@@ -426,14 +410,6 @@ else()
   set(ZLIB_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
   set(BZip2_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
 
-  if(ENABLE_XZ)
-    if(WIN32)
-      find_package(LibLZMA CONFIG REQUIRED)
-    else()
-      set(LibLZMA_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
-    endif()
-  endif()
-
   list(PREPEND CMAKE_PREFIX_PATH "${ARTIFACTS_ROOT_DIR}")
 
   if(WIN32)
@@ -499,11 +475,6 @@ else()
     LIBZIPSHARP_VERSION="${LZS_VERSION}"
     )
 
-  if(ENABLE_XZ)
-    message(STATUS "LZMA: ${LIBLZMA_INCLUDE_DIR}")
-  else()
-    message(STATUS "LZMA: DISABLED")
-  endif()
   message(STATUS "ZSTD: ${Zstd_INCLUDE_DIR}")
   message(STATUS "ZLIB: ${ZLIB_INCLUDE_DIR}")
   message(STATUS "BZ2: ${BZIP2_INCLUDE_DIR}")
@@ -516,20 +487,6 @@ else()
     ${Zstd_INCLUDE_DIR}
     ${CMAKE_BINARY_DIR}/external/libzip
     )
-
-  if(ENABLE_XZ)
-    target_include_directories(
-      ${PROJECT_NAME}
-      PRIVATE
-      ${LIBLZMA_INCLUDE_DIR}
-      )
-
-    target_compile_definitions(
-      ${PROJECT_NAME}
-      PRIVATE
-      HAVE_XZ=1
-      )
-  endif()
 
   target_compile_options(
     ${PROJECT_NAME}
@@ -606,27 +563,15 @@ else()
     set(BZ2_PATH "${CMAKE_BINARY_DIR}/libbz2-fat.a")
     set(ZSTD_PATH "${CMAKE_BINARY_DIR}/libzstd-fat.a")
 
-    if(ENABLE_XZ)
-      set(LZMA_PATH "${CMAKE_BINARY_DIR}/liblzma-fat.a")
-    endif()
-
     make_fat_archive("${ARTIFACTS_ROOT_DIR}/lib/libz.a" "${ARTIFACTS_OTHER_ROOT_DIR}/lib/libz.a" "${ZLIB_PATH}")
     make_fat_archive("${ARTIFACTS_ROOT_DIR}/lib/libbz2.a" "${ARTIFACTS_OTHER_ROOT_DIR}/lib/libbz2.a" "${BZ2_PATH}")
     make_fat_archive("${ARTIFACTS_ROOT_DIR}/lib/libzstd.a" "${ARTIFACTS_OTHER_ROOT_DIR}/lib/libzstd.a" "${ZSTD_PATH}")
-
-    if(ENABLE_XZ)
-      make_fat_archive("${ARTIFACTS_ROOT_DIR}/lib/liblzma.a" "${ARTIFACTS_OTHER_ROOT_DIR}/lib/liblzma.a" "${LZMA_PATH}")
-    endif()
 
     set(LIBS
       ${ZLIB_PATH}
       ${BZ2_PATH}
       ${ZSTD_PATH}
       )
-
-    if(ENABLE_XZ)
-      list(APPEND LIBS ${LZMA_PATH})
-    endif()
   else()
     if(WIN32)
       if(ENABLE_ZLIBNG)
@@ -640,20 +585,12 @@ else()
         ${ARTIFACTS_ROOT_DIR}/lib/bz2.lib
         ${ARTIFACTS_ROOT_DIR}/lib/zstd.lib
         )
-
-      if(ENABLE_XZ)
-        list(APPEND LIBS LibLZMA::LibLZMA)
-      endif()
     else()
       set(LIBS
         ${ARTIFACTS_ROOT_DIR}/lib/libz.a
         ${ARTIFACTS_ROOT_DIR}/lib/libbz2.a
         ${ARTIFACTS_ROOT_DIR}/lib/libzstd.a
         )
-
-      if(ENABLE_XZ)
-        list(APPEND LIBS ${ARTIFACTS_ROOT_DIR}/lib/liblzma.a)
-      endif()
     endif()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,7 @@ else()
 
   set(ZLIB_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
   set(BZip2_ROOT "${ARTIFACTS_ROOT_DIR}" CACHE STRING "" FORCE)
+  set(ENABLE_LZMA False CACHE BOOL "Disable lzma support, even if detected" FORCE)
 
   list(PREPEND CMAKE_PREFIX_PATH "${ARTIFACTS_ROOT_DIR}")
 

--- a/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
+++ b/LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
@@ -9,7 +9,6 @@
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
     <ReferenceNuget Condition="'$(ReferenceNuget)' == ''">False</ReferenceNuget>
     <DefineConstants Condition="'$(OS)' == 'Windows_NT'">$(DefineConstants);WINDOWS</DefineConstants>
-    <DefineConstants Condition=" '$(UseXZ)' == 'True' ">$(DefineConstants);HAVE_XZ</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -32,9 +32,6 @@ namespace Tests {
 			Assert.IsNotEmpty (versions.LibZip, "libzip version must not be empty");
 			Assert.IsNotEmpty (versions.Zlib, "zlib version must not be empty");
 			Assert.IsNotEmpty (versions.ZlibNG, "zlib-ng version must not be empty");
-#if HAVE_XZ
-			Assert.IsNotEmpty (versions.LZMA, "LZMA version must not be empty");
-#endif
 			Assert.IsNotEmpty (versions.LibZipSharp, "LibZipSharp version must not be empty");
 
 			Console.WriteLine ($"LibZipSharp version: {versions.LibZipSharp}");
@@ -42,7 +39,6 @@ namespace Tests {
 			Console.WriteLine ($"libzip version: {versions.LibZip}");
 			Console.WriteLine ($"zlib version: {versions.Zlib}");
 			Console.WriteLine ($"zlib-ng version: {versions.ZlibNG}");
-			Console.WriteLine ($"LZMA version: {versions.LZMA}");
 		}
 
 		[Test]
@@ -217,9 +213,6 @@ namespace Tests {
 		[TestCase (CompressionMethod.Deflate)]
 		[TestCase (CompressionMethod.Bzip2)]
 		[TestCase (CompressionMethod.ZSTD)]
-#if HAVE_XZ
-		[TestCase (CompressionMethod.XZ)]
-#endif
 		public void UpdateEntryCompressionMethod (CompressionMethod method)
 		{
 			var zipStream = new MemoryStream ();

--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -15,6 +15,5 @@
     <_NativeBuildDir>$(MSBuildThisFileDirectory)lzsbuild</_NativeBuildDir>
     <_ExternalDir>$(MSBuildThisFileDirectory)external</_ExternalDir>
     <_MonoPosixNugetVersion>7.1.0-final.1.21458.1</_MonoPosixNugetVersion>
-    <UseXZ Condition=" '$(UseXZ)' == '' ">false</UseXZ>
   </PropertyGroup>
 </Project>

--- a/LibZipSharp/Xamarin.Tools.Zip/Native.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Native.cs
@@ -47,7 +47,6 @@ namespace Xamarin.Tools.Zip
 			public string zlib;
 			public string zlibng;
 			public string zstd;
-			public string lzma;
 			public string libzipsharp;
 		};
 
@@ -149,7 +148,6 @@ namespace Xamarin.Tools.Zip
 				Zlib = ret.zlib ?? String.Empty,
 				ZlibNG = ret.zlibng ?? String.Empty,
 				ZStd = ret.zstd ?? String.Empty,
-				LZMA = ret.lzma ?? String.Empty,
 				LibZipSharp = ret.libzipsharp ?? String.Empty
 			};
 		}

--- a/LibZipSharp/Xamarin.Tools.Zip/Versions.cs
+++ b/LibZipSharp/Xamarin.Tools.Zip/Versions.cs
@@ -22,10 +22,6 @@ namespace Xamarin.Tools.Zip
 			get; internal set;
 		}
 
-		public string LZMA {
-			get; internal set;
-		}
-
 		public string LibZipSharp {
 			get; internal set;
 		}

--- a/LibZipSharp/libZipSharp.csproj
+++ b/LibZipSharp/libZipSharp.csproj
@@ -59,7 +59,6 @@
         <None Include="..\LICENSE" PackagePath="Licences" Pack="true" />
         <None Include="$(_ExternalDir)\libzip\LICENSE" PackagePath="Licences\libzip" Pack="true" />
         <None Include="$(_ExternalDir)\bzip2\LICENSE" PackagePath="Licences\bzip2" Pack="true" />
-        <None Include="$(_ExternalDir)\xz\COPYING.LGPLv2.1" PackagePath="Licences\liblzma" Pack="true" />
         <None Include="$(_ExternalDir)\zlib-ng\LICENSE.md" PackagePath="Licences\zlib-ng" Pack="true" />
     </ItemGroup>
     <ItemGroup>

--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,6 @@ JOBS=""
 CONFIGURATION="RelWithDebInfo"
 REBUILD="no"
 VERBOSE="no"
-USE_XZ="no"
 USE_ZLIBNG="no"
 
 # The color block is pilfered from the dotnet installer script
@@ -79,7 +78,6 @@ where OPTIONS are one or more of:
   -n|--ninja PATH            use ninja at PATH instead of the default of '${NINJA}'
   -m|--cmake PATH            use cmake at PATH instead of the default of '${CMAKE}'
 
-  -x|--xz                    use the XZ library for LZMA support (default: ${USE_XZ})
   -g|--zlib-ng               use the zlib-ng library instead of zlib (default: ${USE_ZLIBNG}
   -c|--configuration NAME    build using configuration NAME instead of the default of '${CONFIGURATION}'
   -j|--jobs NUM              run at most this many build jobs in parallel
@@ -124,16 +122,11 @@ function cmake_configure()
     fi
     shift
 
-    local use_xz
-    if [ "${USE_XZ}" == "yes" ]; then
-        use_xz="-DENABLE_XZ=ON"
-    fi
-
     run_cmake_common \
         -B "${build_dir}" \
         -S "${MY_DIR}" \
         -G "${GENERATOR}" \
-        -DCMAKE_BUILD_TYPE="${CONFIGURATION}" ${use_xz} \
+        -DCMAKE_BUILD_TYPE="${CONFIGURATION}" \
         "$@"
 }
 
@@ -234,11 +227,6 @@ while (( "$#" )); do
                 missing_argument "$1"
             fi
             ;;
-
-        -x|--xz)
-			USE_XZ="yes"
-			GENERATOR="Unix Makefiles"
-			shift ;;
 
 		-g|--zlib-ng) USE_ZLIBNG="yes"; shift ;;
 
@@ -347,7 +335,3 @@ cmake_configure "${LZS_BUILD_DIR}" -DBUILD_LIBZIP=ON "-DARTIFACTS_ROOT_DIR=${ART
 
 print_banner "Building libZipSharpNative"
 cmake_build "${LZS_BUILD_DIR}"
-
-if [ "${USE_XZ}" == "yes" ]; then
-    echo "${BRIGHT_BLUE}DON'T FORGET TO BUILD THE MANAGED CODE WITH THE /p:UseXZ=True OPTION!${NORMAL}"
-fi

--- a/build_windows.bat
+++ b/build_windows.bat
@@ -43,9 +43,6 @@ popd
 external\vcpkg\vcpkg.exe integrate install
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-external\vcpkg\vcpkg.exe install liblzma:x64-windows-static liblzma:x86-windows-static liblzma:arm-windows-static
-if %errorlevel% neq 0 exit /b %errorlevel%
-
 REM 64-bit deps
 mkdir "%DEPS_BUILD_DIR_ROOT_64%"
 cmake %COMMON_CMAKE_PARAMS% ^

--- a/native/version.cc
+++ b/native/version.cc
@@ -2,9 +2,6 @@
 #include <bzlib.h>
 #include <zlib.h>
 #include <zstd.h>
-#if defined (HAVE_XZ)
-#include <lzma.h>
-#endif // def HAVE_XZ
 #include <zipconf.h>
 
 #include "version.hh"
@@ -17,11 +14,6 @@ constexpr char libzlibng_version[] = ZLIBNG_VERSION;
 #else
 constexpr char libzlibng_version[] = "not used";
 #endif // ndef ZLIBNG_VERSION
-#if defined (HAVE_XZ)
-constexpr char lzma_version[] = LZMA_VERSION_STRING;
-#else
-constexpr char lzma_version[] = "not supported";
-#endif // def HAVE_XZ
 
 void lzs_get_versions (LZSVersions *versions)
 {
@@ -34,6 +26,5 @@ void lzs_get_versions (LZSVersions *versions)
 	versions->zlib = strdup (libzlib_version);
 	versions->zlibng = strdup (libzlibng_version);
 	versions->zstd = strdup (ZSTD_versionString ());
-	versions->lzma = strdup (lzma_version);
 	versions->libzipsharp = strdup (libzipsharp_version);
 }

--- a/native/version.hh
+++ b/native/version.hh
@@ -10,7 +10,6 @@ struct LZSVersions
 	const char *zlib;
 	const char *zlibng;
 	const char *zstd;
-	const char *lzma;
 	const char *libzipsharp;
 };
 


### PR DESCRIPTION
Context: https://tukaani.org/xz-backdoor/
    
In light of the recently discovered backdoor in xz-utils and its
GitHub repository being blocked, remove the submodule from LibZipSharp
and remove all the code to enable lzma compression support in it.

Note that XZ support was disabled by default and was never released
as part of any official LibZipSharp nugets/binaries, therefore we
are not affected in any form or shape by the issue.

The submodule is removed so that it is possible to clone and initialize
this repository.  When the issues surrounding xz-utils are fixed, we can
restore support by reverting this commit.