### PR TITLE
Fix the elusive invalid zip archive issue that has been a problem for ages!

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build LibZipSharp",
             "type": "shell",
-            "command": "msbuild LibZipSharp/libZipSharp.csproj /restore /t:Build",
+            "command": "dotnet build LibZipSharp/libZipSharp.csproj -t:Build",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -18,7 +18,7 @@
         {
             "label": "Pack LibZipSharp Nuget",
             "type": "shell",
-            "command": "msbuild LibZipSharp/libZipSharp.csproj /t:Pack",
+            "command": "dotnet pack LibZipSharp/libZipSharp.csproj",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -30,7 +30,7 @@
         {
             "label": "Clean LibZipSharp",
             "type": "shell",
-            "command": "msbuild LibZipSharp/libZipSharp.csproj /restore /t:Clean",
+            "command": "dotnet build LibZipSharp/libZipSharp.csproj -t:Clean",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -42,7 +42,7 @@
         {
             "label": "Build LibZipSharp Unit Tests",
             "type": "shell",
-            "command": "msbuild LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj /restore /t:Build /p:ReferenceNuget=False",
+            "command": "dotnet build LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj -t:Build -p:ReferenceNuget=False",
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -51,17 +51,5 @@
                 "$msCompile"
             ]
         },
-        {
-            "label": "Run LibZipSharp Unit Tests",
-            "type": "shell",
-            "command": "msbuild LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj /restore /t:RunNunitTests /p:ReferenceNuget=False",
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            },
-            "problemMatcher": [
-                "$msCompile"
-            ]
-        }
     ]
 }

--- a/LibZipSharp.UnitTest/ZipTests.cs
+++ b/LibZipSharp.UnitTest/ZipTests.cs
@@ -345,7 +345,7 @@ namespace Tests {
 				}
 
 				stream.Position = 0;
-				using (var zip = ZipArchive.Open (stream)) {
+				using (var zip = ZipArchive.Open (stream, strictConsistencyChecks: true)) {
 					Assert.AreEqual (3, zip.EntryCount);
 					foreach (var e in zip) {
 						Console.WriteLine (e.FullName);
@@ -354,7 +354,7 @@ namespace Tests {
 				}
 
 				stream.Position = 0;
-				using (var zip = ZipArchive.Open (stream)) {
+				using (var zip = ZipArchive.Open (stream, strictConsistencyChecks: true)) {
 					Assert.AreEqual (2, zip.EntryCount);
 					zip.AddEntry ("info.json", File.ReadAllText (filePath), Encoding.UTF8, CompressionMethod.Deflate);
 				}
@@ -373,6 +373,40 @@ namespace Tests {
 						}
 
 					}
+				}
+			}
+		}
+
+		[Test]
+		public void EnumerateOnEmptyThenAddFiles ()
+		{
+			File.WriteAllText ("file1.txt", TEXT);
+			File.WriteAllText ("file2.txt", TEXT);
+			string filePath = Path.GetFullPath ("file1.txt");
+			if (File.Exists ("enumerateonempty.zip"))
+				File.Delete ("enumerateonempty.zip");
+
+			
+			using (var stream = File.Create ("test-archive-write.zip"))
+			using (var zip = ZipArchive.Create (stream)) {
+				foreach (var entry in zip) {
+					Console.Write (entry.FullName);
+				}
+				ZipEntry e;
+				e = zip.AddFile (filePath, "/path/ZipTestCopy1.exe");
+				filePath = Path.GetFullPath ("file2.txt");
+				e = zip.AddFile (filePath, "/path/ZipTestCopy2.exe");
+
+				foreach (var entry in zip) {
+					Console.Write (entry.FullName);
+				}
+
+				zip.Close ();
+			}
+
+			using (var zip = ZipArchive.Open ("test-archive-write.zip", FileMode.Open, strictConsistencyChecks: true)) {
+				foreach (var entry in zip) {
+					Console.Write (entry.FullName);
 				}
 			}
 		}

--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -1,8 +1,8 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <_LibZipSharpAssemblyVersionMajor>3</_LibZipSharpAssemblyVersionMajor>
-    <_LibZipSharpAssemblyVersionMinor>2</_LibZipSharpAssemblyVersionMinor>
-    <_LibZipSharpAssemblyVersionPatch>1</_LibZipSharpAssemblyVersionPatch>
+    <_LibZipSharpAssemblyVersionMinor>3</_LibZipSharpAssemblyVersionMinor>
+    <_LibZipSharpAssemblyVersionPatch>0</_LibZipSharpAssemblyVersionPatch>
     <_LibZipSharpAssemblyVersion>$(_LibZipSharpAssemblyVersionMajor).$(_LibZipSharpAssemblyVersionMinor).$(_LibZipSharpAssemblyVersionPatch)</_LibZipSharpAssemblyVersion>
     <_NativeLibraryVersionForName>$(_LibZipSharpAssemblyVersionMajor)-$(_LibZipSharpAssemblyVersionMinor)</_NativeLibraryVersionForName>
     <_NativeLibraryBaseName>libZipSharpNative-$(_NativeLibraryVersionForName)</_NativeLibraryBaseName>

--- a/LibZipSharp.props
+++ b/LibZipSharp.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <_LibZipSharpAssemblyVersionMajor>3</_LibZipSharpAssemblyVersionMajor>
     <_LibZipSharpAssemblyVersionMinor>2</_LibZipSharpAssemblyVersionMinor>
-    <_LibZipSharpAssemblyVersionPatch>0</_LibZipSharpAssemblyVersionPatch>
+    <_LibZipSharpAssemblyVersionPatch>1</_LibZipSharpAssemblyVersionPatch>
     <_LibZipSharpAssemblyVersion>$(_LibZipSharpAssemblyVersionMajor).$(_LibZipSharpAssemblyVersionMinor).$(_LibZipSharpAssemblyVersionPatch)</_LibZipSharpAssemblyVersion>
     <_NativeLibraryVersionForName>$(_LibZipSharpAssemblyVersionMajor)-$(_LibZipSharpAssemblyVersionMinor)</_NativeLibraryVersionForName>
     <_NativeLibraryBaseName>libZipSharpNative-$(_NativeLibraryVersionForName)</_NativeLibraryBaseName>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,11 @@ extends:
                 archiveType: 7z
                 replaceExistingArchive: true
                 archiveFile: $(Build.ArtifactStagingDirectory)\libzip-windows-arm-x64.7z
+            - script: |
+                7z t $(Build.ArtifactStagingDirectory)\libzip-windows-arm-x64.7z
+                7z t $(Build.ArtifactStagingDirectory)\libzip-windows-x64.7z
+                7z t $(Build.ArtifactStagingDirectory)\libzip-windows-x86.7z
+              displayName: Test Archives
 
         - job: buildLinux
           pool:


### PR DESCRIPTION
Fixes https://github.com/xamarin/xamarin-android/issues/8988

We had this odd corrupt zip file issue which kept cropping up on our Azure Pipelines builds. 
We had no idea what caused it until now. Some of the data for the local headers of an item (not the central directory) would be written incorrectly.  This would result in a zip which may or may not be extractable, it would depend on how resilient the software extracting the data would be. 

So, what was happening here was that (sometimes) libzip would start writing some data (most likely the local file header) using our stream source callback, and it would seek a few bytes into the data and then tried to seek back to the beginning. The latter seek was done by giving the seek operation of the callback an offset of 0 which, unfortunately, was also used by the code as a guard as to whether or not to even perform the seek operation. The effect was that we ignored the seek to 0 and the stream remained at whatever the previous seek location was requested, thus corrupting data. It happened only on the very first entry, since that was the only one which would have position 0 within its range.

We discovered that just enabling the strict consistency checks would uncover the issue, so that has been enabled in 
a number of unit tests. Once we did that it turns out we were writting the corrupt data ALL the TIME!.
Fixing up the seeking code to take into account that we might want to see to `0` fixed the issue.
