### PR TITLE
[build] Replace `DotNetCoreCLI@2` with direct `dotnet` commands

### DIFF
--- a/yaml-templates/stage-build.yml
+++ b/yaml-templates/stage-build.yml
@@ -145,18 +145,10 @@ stages:
         rm $(Build.ArtifactStagingDirectory)/libzip-linux-*.tar.bz2
         rm $(Build.ArtifactStagingDirectory)/libzip-windows-*.tar.bz2
       displayName: 'Find libzip'
-    - task: DotNetCoreCLI@2
+    - script: dotnet build LibZipSharp/libZipSharp.csproj -c Release -v:diag -p:RunningOnCI=true
       displayName: 'Build solution libZipSharp.csproj'
-      inputs:
-        projects:  LibZipSharp/libZipSharp.csproj
-        configuration: Release
-        arguments: -v:diag -p:RunningOnCI=true
-    - task: DotNetCoreCLI@2
+    - script: dotnet build LibZipSharp/libZipSharp.csproj -c Release -t:Pack
       displayName: NuGet pack libZipSharp
-      inputs:
-        projects:  LibZipSharp/libZipSharp.csproj
-        configuration: Release
-        arguments: -t:Pack
     - task: CopyFiles@2
       displayName: Copy nupkg
       inputs:

--- a/yaml-templates/stage-test.yml
+++ b/yaml-templates/stage-test.yml
@@ -36,19 +36,16 @@ stages:
       inputs:
         artifactName: nuget
         downloadPath: $(Build.SourcesDirectory)
-    - task: DotNetCoreCLI@2
+    - script: dotnet build LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj -c Release -p:ReferenceNuget=True -v:diag
       displayName: 'Build solution LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj'
-      inputs:
-        projects:  LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
-        configuration: Release
-        arguments: -p:ReferenceNuget=True -v:diag
-    - task: DotNetCoreCLI@2
+    - script: dotnet test LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj -c Release -p:ReferenceNuget=True -v:diag --logger trx --results-directory $(Build.SourcesDirectory)/TestResults
       displayName: 'Run Unit tests for .net'
+    - task: PublishTestResults@2
+      displayName: Publish test results
+      condition: succeededOrFailed()
       inputs:
-        command: test
-        projects:  LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
-        configuration: Release
-        arguments: -p:ReferenceNuget=True -v:diag
+        testResultsFormat: VSTest
+        testResultsFiles: '$(Build.SourcesDirectory)/TestResults/**/*.trx'
 
   - job: testmacos
     displayName: 'Test MacOS'
@@ -68,19 +65,16 @@ stages:
       inputs:
         artifactName: nuget
         downloadPath: $(Build.SourcesDirectory)
-    - task: DotNetCoreCLI@2
+    - script: dotnet build LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj -c Release -p:ReferenceNuget=True -v:diag
       displayName: 'Build solution LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj'
-      inputs:
-        projects:  LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
-        configuration: Release
-        arguments: -p:ReferenceNuget=True -v:diag
-    - task: DotNetCoreCLI@2
+    - script: dotnet test LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj -c Release -p:ReferenceNuget=True -v:diag --logger trx --results-directory $(Build.SourcesDirectory)/TestResults
       displayName: 'Run Tests under .net'
+    - task: PublishTestResults@2
+      displayName: Publish test results
+      condition: succeededOrFailed()
       inputs:
-        command: test
-        projects:  LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
-        configuration: Release
-        arguments: -p:ReferenceNuget=True -v:diag
+        testResultsFormat: VSTest
+        testResultsFiles: '$(Build.SourcesDirectory)/TestResults/**/*.trx'
 
   - job: testwindows
     displayName: 'Test Windows'
@@ -105,16 +99,13 @@ stages:
       inputs:
         artifactName: nuget
         downloadPath: $(Build.SourcesDirectory)
-    - task: DotNetCoreCLI@2
+    - script: dotnet build LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj -c Release -p:ReferenceNuget=True -v:diag
       displayName: 'Build solution LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj'
-      inputs:
-        projects:  LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
-        configuration: Release
-        arguments: -p:ReferenceNuget=True -v:diag
-    - task: DotNetCoreCLI@2
+    - script: dotnet test LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj -c Release -p:ReferenceNuget=True -v:diag --logger trx --results-directory $(Build.SourcesDirectory)/TestResults
       displayName: 'Run Tests LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj'
+    - task: PublishTestResults@2
+      displayName: Publish test results
+      condition: succeededOrFailed()
       inputs:
-        command: test
-        projects:  LibZipSharp.UnitTest/LibZipSharp.UnitTest.csproj
-        configuration: Release
-        arguments: -p:ReferenceNuget=True -v:diag
+        testResultsFormat: VSTest
+        testResultsFiles: '$(Build.SourcesDirectory)/TestResults/**/*.trx'


### PR DESCRIPTION
The DotNetCoreCLI@2 task adds NuGet feed sources as build tags. Windows paths like 'c:\program files\dotnet\library-packs' contain colons that Azure DevOps REST API rejects:

```
  'A potentially dangerous Request.Path value was detected from the client (:).'
```

Replace all DotNetCoreCLI@2 usages with plain 'dotnet build' and 'dotnet test' script commands which don't have this behavior. 
All NuGet feeds used are public so no authenticated feed handling is needed.